### PR TITLE
Store vz matrices

### DIFF
--- a/configure
+++ b/configure
@@ -53,7 +53,8 @@ function set_config_options()
             --use-mkl-cblas )
                 USE_MKL_CBLAS="-DUSE_MKL_CBLAS";;
             --enable-openmp )
-                CPPFLAGS_OMP="-fopenmp";;
+                CPPFLAGS_OMP="-fopenmp"
+                ENABLE_OMP="-DENABLE_OMP";;
             --enable-tbb )
                 CPPFLAGS_OMP="-tbb";;
             --use-tophat-zbin )
@@ -221,6 +222,8 @@ function set_omp_flags()
         LDLIBS_OMP=""
         MKL_THREAD_LIBS="-lmkl_sequential -lmkl_core"
     fi
+
+    update_makefile_vars "${CPPFLAGS_OMP}" "" "${LDLIBS_OMP}"
 }
 # -----------------------------------------------------------------------------
 
@@ -525,6 +528,7 @@ MORECPPFLAGS=""
 
 OPT="-O3"
 ENABLE_MPI=""
+ENABLE_OMP=""
 binz_fn="-DTRIANGLE_Z_BINNING_FN"
 ENABLE_FISHER_OPTIMIZATION=""
 USE_MKL_CBLAS=""
@@ -556,13 +560,10 @@ fi
 mkdir -p ${srcdir}/build-aux
 check_compiler_support
 set_omp_flags
-CPPFLAGS=$(echo "${CPPFLAGS_OMP} ${CPPFLAGS}" | sed 's/ *$//')
 set_gsl_inc_lib
 set_fftw3_inc_lib
 set_cfitsio_inc_lib
 set_cblas_inc_lib
-
-update_makefile_vars "" "" "${LDLIBS_OMP}"
 
 if [[ ! -z "${ENABLE_MPI}" ]]; then
     exec="srun -n 1 "
@@ -571,7 +572,7 @@ fi
 
 update_makefile_vars "" "" "${suffix_libs}"
 
-MORECPPFLAGS="${ENABLE_MPI} ${ENABLE_FISHER_OPTIMIZATION} ${ENABLE_FIDUCIAL_GROWTH_Z} ${binz_fn}"
+MORECPPFLAGS="${ENABLE_MPI} ${ENABLE_OMP} ${ENABLE_FISHER_OPTIMIZATION} ${ENABLE_FIDUCIAL_GROWTH_Z} ${binz_fn}"
 MORECPPFLAGS=$(echo $MORECPPFLAGS | sed 's/ *$//')
 
 # Save makefile

--- a/core/chunk_estimate.cpp
+++ b/core/chunk_estimate.cpp
@@ -28,7 +28,7 @@ void _check_isnan(double *mat, int size, std::string msg)
 inline
 void _getVandZ(double li, double lj, double &v_ij, double &z_ij)
 {
-    v_ij = SPEED_OF_LIGHT * log(lj / li);
+    v_ij = SPEED_OF_LIGHT * fabs(log(lj / li));
     z_ij = sqrt(li * lj) / LYA_REST - 1.;
 }
 
@@ -276,7 +276,6 @@ void Chunk::_setQiMatrix(double *qi, int i_kz)
         inter_mat[i] = interp_deriv_kn->evaluate(_vmatrix[i]);
         inter_mat[i] *= bins::redshiftBinningFunction(_zmatrix[i], zm);
     }
-
 
     t_interp = mytime::timer.getTime() - t;
 

--- a/core/chunk_estimate.cpp
+++ b/core/chunk_estimate.cpp
@@ -226,6 +226,7 @@ double Chunk::getComputeTimeEst(const qio::QSOFile &qmaster, int i1, int i2)
 void Chunk::_setVZMatrices() {
     LOG::LOGGER.DEB("Setting v & z matrices\n");
 
+    #pragma omp parallel for
     for (int i = 0; i < _matrix_n; ++i)
     {
         double li = _matrix_lambda[i];

--- a/core/chunk_estimate.hpp
+++ b/core/chunk_estimate.hpp
@@ -103,7 +103,8 @@ public:
     void computeFisherMatrix();
 
     // Pass fit values for the power spectrum for numerical stability
-    void oneQSOiteration(const double *ps_estimate,
+    void oneQSOiteration(
+        const double *ps_estimate,
         std::vector<std::unique_ptr<double[]>> &dbt_sum_vector,
         double *fisher_sum);
 

--- a/core/chunk_estimate.hpp
+++ b/core/chunk_estimate.hpp
@@ -45,7 +45,8 @@ protected:
 
     // Uninitialized arrays
     // Oversampled resomat specifics
-    double *_finer_lambda, *_finer_matrix;
+    bool on_oversampling;
+    double *_finer_lambda, *_finer_matrix, *_vmatrix, *_zmatrix;
 
     // DATA_SIZE x DATA_SIZE sized matrices 
     // Note that noise matrix is diagonal and stored as pointer to its array 
@@ -75,6 +76,7 @@ protected:
     // void _saveIndividualResult();
 
     void _setFiducialSignalMatrix(double *sm);
+    void _setVZMatrices();
     void _setQiMatrix(double *qi, int i_kz);
     void _addMarginalizations();
     void _getWeightedMatrix(double *m);

--- a/core/quadratic_estimate.cpp
+++ b/core/quadratic_estimate.cpp
@@ -408,19 +408,26 @@ void OneDQuadraticPowerEstimate::iterate()
 
         LOG::LOGGER.DEB("MPI All reduce.\n");
         if (!specifics::USE_PRECOMPUTED_FISHER)
-            MPI_Allreduce(MPI_IN_PLACE, fisher_matrix_sum.get(), bins::FISHER_SIZE,
+            MPI_Allreduce(
+                MPI_IN_PLACE,
+                fisher_matrix_sum.get(), bins::FISHER_SIZE,
                 MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
 
         for (int dbt_i = 0; dbt_i < 3; ++dbt_i)
-            MPI_Allreduce(MPI_IN_PLACE, dbt_estimate_sum_before_fisher_vector[dbt_i].get(), 
+            MPI_Allreduce(
+                MPI_IN_PLACE,
+                dbt_estimate_sum_before_fisher_vector[dbt_i].get(), 
                 bins::TOTAL_KZ_BINS, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
         #endif
 
         // If fisher is precomputed, copy this into fisher_matrix_sum. 
         // oneQSOiteration iteration will not compute fishers as well.
         if (specifics::USE_PRECOMPUTED_FISHER)
-            std::copy(precomputed_fisher.begin(), precomputed_fisher.end(), 
+            std::copy(
+                precomputed_fisher.begin(), precomputed_fisher.end(), 
                 fisher_matrix_sum.get());
+
+        mxhelp::copyUpperToLower(fisher_matrix_sum.get(), bins::TOTAL_KZ_BINS);
 
         try
         {

--- a/io/qso_file.cpp
+++ b/io/qso_file.cpp
@@ -148,7 +148,7 @@ void QSOFile::_cutMaskedBoundary(double sigma_cut)
     shift += ni1;
     arr_size = ni2-ni1;
 
-    if (arr_size < 0)
+    if (arr_size <= 0)
         throw std::runtime_error(
             "Empty spectrum when masked pixels at boundary are removed!"
         );

--- a/mathtools/discrete_interpolation.cpp
+++ b/mathtools/discrete_interpolation.cpp
@@ -11,36 +11,34 @@ bool isClose(double a, double b, double relerr=1e-5, double abserr=1e-8)
 }
 
 inline
-bool allClose(const double *a, const double *b, long size)
+bool allClose(const double *a, const double *b, int size)
 {
     bool result = true;
-    for (long i = 0; i < size; ++i)
+    for (int i = 0; i < size; ++i)
         result &= isClose(a[i], b[i]);
     return result;
 }
 
-DiscreteInterpolation1D::DiscreteInterpolation1D(double x_start, double delta_x, const double *y_arr, long Nsize)
-: x1(x_start), dx(delta_x), N(Nsize)
+DiscreteInterpolation1D::DiscreteInterpolation1D(
+        double x_start, double delta_x, const double *y_arr, int Nsize
+) : x1(x_start), dx(delta_x), N(Nsize)
 {
-    x2 = x1 + dx * (N-1);
+    x2 = x1 + dx * (N - 1);
     y = new double[N];
-    std::copy(y_arr, y_arr+N, y);
-}
-
-void DiscreteInterpolation1D::_limitBoundary(double &x)
-{
-    if (x >= x2)        x = x2 - 1e-6;
-    else if (x < x1)    x = x1;
+    std::copy(y_arr, y_arr + N, y);
 }
 
 double DiscreteInterpolation1D::evaluate(double x)
 {
-    _limitBoundary(x);
+    double xx = (x - x1) / dx;
+    int n = (int) xx;
 
-    long n = (x-x1)/dx;
-    double dn = (x-x1)/dx - n, y1 = y[n], y2=y[n+1];
+    if (n < 0) n = 0;
+    else if (n >= N - 1) n = N - 2;
 
-    return y1*(1-dn) + y2*dn;
+    double dn = xx - n, y1 = y[n], y2 = y[n + 1];
+
+    return y1 * (1 - dn) + y2 * dn;
 }
 
 bool DiscreteInterpolation1D::operator==(const DiscreteInterpolation1D &rhs) const
@@ -52,9 +50,10 @@ bool DiscreteInterpolation1D::operator==(const DiscreteInterpolation1D &rhs) con
     return result;
 }
 
-DiscreteInterpolation2D::DiscreteInterpolation2D(double x_start, double delta_x, double y_start, double delta_y,
-    const double *z_arr, long Nxsize, long Nysize)
-: x1(x_start), dx(delta_x), y1(y_start), dy(delta_y), Nx(Nxsize), Ny(Nysize)
+DiscreteInterpolation2D::DiscreteInterpolation2D(
+        double x_start, double delta_x, double y_start, double delta_y,
+        const double *z_arr, int Nxsize, int Nysize
+) : x1(x_start), dx(delta_x), y1(y_start), dy(delta_y), Nx(Nxsize), Ny(Nysize)
 {
     x2 = x1 + dx * (Nx-1);
     y2 = y1 + dy * (Ny-1);
@@ -64,35 +63,25 @@ DiscreteInterpolation2D::DiscreteInterpolation2D(double x_start, double delta_x,
     std::copy(z_arr, z_arr+size, z);
 }
 
-long DiscreteInterpolation2D::_getIndex(long nx, long ny)
-{
-    return nx + Nx*ny;
-}
-
-void DiscreteInterpolation2D::_limitBoundary(double &x, double &y)
-{
-    if (x >= x2)        x = x2 - 1e-6;
-    else if (x < x1)    x = x1;
-
-    if (y >= y2)        y = y2 - 1e-6;
-    else if (y < y1)    y = y1;
-}
-
 double DiscreteInterpolation2D::evaluate(double x, double y)
 {
-    _limitBoundary(x, y);
+    double xx = (x - x1) / dx, yy = (y - y1) / dy;
+    int nx = (int) xx, ny = (int) yy;
 
-    long nx = (x-x1)/dx;
-    long ny = (y-y1)/dy;
-    long ind = _getIndex(nx, ny);
+    if (nx < 0) nx = 0;
+    else if (nx >= Nx - 1) nx = Nx - 2;
 
-    double dnx = (x-x1)/dx - nx;
-    double dny = (y-y1)/dy - ny;
+    if (ny < 0) ny = 0;
+    else if (ny >= Ny - 1) ny = Ny - 2;
 
-    double result = z[ind] * (1-dnx) * (1-dny)
-    + z[ind+1] * (dnx) * (1-dny)
-    + z[ind+Nx] * (1-dnx) * (dny)
-    + z[ind+Nx+1] * (dnx) * (dny);
+    int ind = _getIndex(nx, ny);
+    double dnx = xx - nx, dny = yy - ny;
+
+    double result =
+        z[ind] * (1 - dnx) * (1 - dny)
+        + z[ind + 1] * (dnx) * (1 - dny)
+        + z[ind + Nx] * (1 - dnx) * (dny)
+        + z[ind + Nx + 1] * (dnx) * (dny);
 
     return result;
 }

--- a/mathtools/discrete_interpolation.hpp
+++ b/mathtools/discrete_interpolation.hpp
@@ -6,16 +6,16 @@
 // Stores a copy of y array.
 // Assumes evenly spaced x.
 // Linearly interpolates
-// x equals to the boundary when it exceeds in either end
+// Out of bound values are extrapolated
 class DiscreteInterpolation1D
 {
     double x1, x2, dx;
     double *y;
-    long N;
+    int N;
 
-    void _limitBoundary(double &x);
 public:
-    DiscreteInterpolation1D(double x_start, double delta_x, const double *y_arr, long Nsize);
+    DiscreteInterpolation1D(
+        double x_start, double delta_x, const double *y_arr, int Nsize);
     ~DiscreteInterpolation1D() { delete [] y; };
     bool operator==(const DiscreteInterpolation1D &rhs) const;
     bool operator!=(const DiscreteInterpolation1D &rhs) const
@@ -30,15 +30,16 @@ public:
 // x and y equal to the boundary when either exceeds in either end
 class DiscreteInterpolation2D
 {
-    double  x1, x2, dx, y1, y2, dy;
+    double x1, x2, dx, y1, y2, dy;
     double *z;
-    long    Nx, Ny, size;
+    int Nx, Ny, size;
 
-    long _getIndex(long nx, long ny);
-    void _limitBoundary(double &x, double &y);
+    inline
+    int _getIndex(int nx, int ny) {  return nx + Nx * ny; };
 public:
-    DiscreteInterpolation2D(double x_start, double delta_x, double y_start, double delta_y,
-        const double *z_arr, long Nxsize, long Nysize);
+    DiscreteInterpolation2D(
+        double x_start, double delta_x, double y_start, double delta_y,
+        const double *z_arr, int Nxsize, int Nysize);
     ~DiscreteInterpolation2D() { delete [] z; };
     bool operator==(const DiscreteInterpolation2D &rhs) const;
     bool operator!=(const DiscreteInterpolation2D &rhs) const

--- a/mathtools/matrix_helper.cpp
+++ b/mathtools/matrix_helper.cpp
@@ -501,33 +501,8 @@ namespace mxhelp
         }
     }
 
-    // void DiaMatrix::sandwichOld(double *inplace)
-    // {
-    //     if (sandwich_buffer == NULL)
-    //         sandwich_buffer = new double[ndim*ndim];
-
-    //     multiply('L', 'N', inplace, sandwich_buffer);
-    //     multiply('R', 'T', sandwich_buffer, inplace);
-    // }
-
-    void DiaMatrix::multiplyLeft(
-            CBLAS_TRANSPOSE TRANS_A, const double* A, double *B) {
-        std::fill_n(B, ndim*ndim, 0);
-
-        int inc_a = 1, row_step_a = ndim;
-
-        if (TRANS_A == CblasNoTrans) {
-            inc_a = 1;
-            row_step_a = ndim;
-        }
-        // Switch to column ordering
-        else if (TRANS_A == CblasTrans) {
-            inc_a = ndim;
-            row_step_a = 1;
-        }
-        else
-            throw std::runtime_error(
-                "DiaMatrix multiply transpose wrong character!");
+    void DiaMatrix::multiplyLeft(const double* A, double *B) {
+        std::fill_n(B, ndim * ndim, 0);
 
         for (int d = 0; d < ndiags; ++d)
         {
@@ -536,17 +511,40 @@ namespace mxhelp
                 A1 = std::max(0, off),
                 B1 = std::max(0, -off);
 
-            const double *Aslice, *dia_slice = _getDiagonal(d);
-            double       *Bslice;
-
-            Aslice = A + A1*row_step_a;
-            Bslice = B + B1*ndim;
+            const double
+                *Aslice = A + A1 * ndim,
+                *dia_slice = _getDiagonal(d);
+            double *Bslice = B + B1 * ndim;
 
             for (int i = 0; i < nmult; ++i)
             {
-                cblas_daxpy(ndim, *(dia_slice+i), Aslice, inc_a, Bslice, 1);
+                cblas_daxpy(ndim, dia_slice[i], Aslice, 1, Bslice, 1);
                 Bslice += ndim;
-                Aslice += row_step_a;
+                Aslice += ndim;
+            }
+        }
+    }
+
+    void DiaMatrix::multiplyRightT(const double* A, double *B) {
+        std::fill_n(B, ndim * ndim, 0);
+
+        for (int d = 0; d < ndiags; ++d)
+        {
+            int off = -offsets[d], 
+                nmult = ndim - abs(off),
+                A1 = std::max(0, -off),
+                B1 = std::max(0, off);
+
+            const double *Aslice = A + A1, *dia_slice = _getDiagonal(d);
+            double *Bslice = B + B1;
+
+            for (int i = 0; i < ndim; ++i)
+            {
+                for (int j = 0; j < nmult; ++j)
+                    Bslice[j] += dia_slice[j] * Aslice[j];
+
+                Bslice += ndim;
+                Aslice += ndim;
             }
         }
     }
@@ -556,8 +554,8 @@ namespace mxhelp
         if (sandwich_buffer == NULL)
             sandwich_buffer = new double[ndim*ndim];
 
-        multiplyLeft(CblasNoTrans, inplace, sandwich_buffer);
-        multiplyLeft(CblasTrans, sandwich_buffer, inplace);
+        multiplyLeft(inplace, sandwich_buffer);
+        multiplyRightT(sandwich_buffer, inplace);
     }
 
     double DiaMatrix::getMinMemUsage()
@@ -579,8 +577,8 @@ namespace mxhelp
 
     // class OversampledMatrix
     OversampledMatrix::OversampledMatrix(
-            int n1, int nelem_prow, int osamp, double dlambda) : 
-        sandwich_buffer(NULL), nrows(n1), nelem_per_row(nelem_prow),
+            int n1, int nelem_prow, int osamp, double dlambda
+    ) : sandwich_buffer(NULL), nrows(n1), nelem_per_row(nelem_prow),
         oversampling(osamp)
     {
         ncols = nrows*oversampling + nelem_per_row-1;

--- a/mathtools/matrix_helper.cpp
+++ b/mathtools/matrix_helper.cpp
@@ -75,7 +75,6 @@ namespace mxhelp
 {
     void copyUpperToLower(double *A, int N)
     {
-        #pragma omp parallel for
         for (int i = 1; i < N; ++i)
             cblas_dcopy(i, A+i, N, A+N*i, 1);
     }
@@ -606,7 +605,6 @@ namespace mxhelp
     // B should be nrows x ncols, will be initialized to zero
     void OversampledMatrix::multiplyLeft(const double* A, double *B)
     {
-        #pragma omp parallel for
         for (int i = 0; i < nrows; ++i)
         {
             double *bsub = B + i * ncols;
@@ -626,7 +624,6 @@ namespace mxhelp
     // B should be nrows x nrows, will be initialized to zero
     void OversampledMatrix::multiplyRight(const double* A, double *B)
     {
-        #pragma omp parallel for
         for (int i = 0; i < nrows; ++i)
         {
             double *bsub = B + i;

--- a/mathtools/matrix_helper.cpp
+++ b/mathtools/matrix_helper.cpp
@@ -522,15 +522,15 @@ namespace mxhelp
             row_step_a = 1;
         }
         else
-            throw std::runtime_error("DiaMatrix multiply transpose wrong character!");
+            throw std::runtime_error(
+                "DiaMatrix multiply transpose wrong character!");
 
         for (int d = 0; d < ndiags; ++d)
         {
             int off = offsets[d], 
                 nmult = ndim - abs(off),
-                A1 = abs(off), B1 = 0;
-
-            if (off < 0) std::swap(A1, B1);
+                A1 = std::max(0, off),
+                B1 = std::max(0, -off);
 
             const double *Aslice, *dia_slice = _getDiagonal(d);
             double       *Bslice;

--- a/mathtools/matrix_helper.cpp
+++ b/mathtools/matrix_helper.cpp
@@ -407,23 +407,25 @@ namespace mxhelp
     }
 
     void DiaMatrix::multiply(
-            char SIDER, char TRANSR, const double* A, double *B) {
+            CBLAS_SIDE SIDER, CBLAS_TRANSPOSE TRANSR,
+            const double* A, double *B) {
         std::fill_n(B, ndim*ndim, 0);
 
         int transpose = 1;
 
-        if (TRANSR == 'N' || TRANSR == 'n')
+        if (TRANSR == CblasNoTrans)
             transpose = 1;
-        else if (TRANSR == 'T' || TRANSR == 't')
+        else if (TRANSR == CblasTrans)
             transpose = -1;
         else
-            throw std::runtime_error("DiaMatrix multiply transpose wrong character!");
+            throw std::runtime_error(
+                "DiaMatrix multiply transpose wrong character!");
 
-        bool lside = (SIDER == 'L' || SIDER == 'l'),
-             rside = (SIDER == 'R' || SIDER == 'r');
+        bool lside = (SIDER == CblasLeft), rside = (SIDER == CblasRight);
         
         if (!lside && !rside)
-            throw std::runtime_error("DiaMatrix multiply SIDER wrong character!");
+            throw std::runtime_error(
+                "DiaMatrix multiply SIDER wrong character!");
 
         /* Left Side:
         if offset > 0 (upper off-diagonals), 
@@ -505,17 +507,17 @@ namespace mxhelp
     // }
 
     void DiaMatrix::multiplyLeft(
-            char TRANS_A, const double* A, double *B) {
+            CBLAS_TRANSPOSE TRANS_A, const double* A, double *B) {
         std::fill_n(B, ndim*ndim, 0);
 
         int inc_a = 1, row_step_a = ndim;
 
-        if (TRANS_A == 'N' || TRANS_A == 'n') {
+        if (TRANS_A == CblasNoTrans) {
             inc_a = 1;
             row_step_a = ndim;
         }
         // Switch to column ordering
-        else if (TRANS_A == 'T' || TRANS_A == 't') {
+        else if (TRANS_A == CblasTrans) {
             inc_a = ndim;
             row_step_a = 1;
         }
@@ -550,8 +552,8 @@ namespace mxhelp
         if (sandwich_buffer == NULL)
             sandwich_buffer = new double[ndim*ndim];
 
-        multiplyLeft('N', inplace, sandwich_buffer);
-        multiplyLeft('T', sandwich_buffer, inplace);
+        multiplyLeft(CblasNoTrans, inplace, sandwich_buffer);
+        multiplyLeft(CblasTrans, sandwich_buffer, inplace);
     }
 
     double DiaMatrix::getMinMemUsage()
@@ -572,8 +574,10 @@ namespace mxhelp
     }
 
     // class OversampledMatrix
-    OversampledMatrix::OversampledMatrix(int n1, int nelem_prow, int osamp, double dlambda) : 
-        sandwich_buffer(NULL), nrows(n1), nelem_per_row(nelem_prow), oversampling(osamp)
+    OversampledMatrix::OversampledMatrix(
+            int n1, int nelem_prow, int osamp, double dlambda) : 
+        sandwich_buffer(NULL), nrows(n1), nelem_per_row(nelem_prow),
+        oversampling(osamp)
     {
         ncols = nrows*oversampling + nelem_per_row-1;
         nvals = nrows*nelem_per_row;
@@ -605,7 +609,8 @@ namespace mxhelp
             // double *rrow = _getRow(i), *bsub = B + i*ncols;
             // const double *Asub = A + i*ncols*oversampling;
 
-            cblas_dgemv(CblasRowMajor, CblasTrans,
+            cblas_dgemv(
+                CblasRowMajor, CblasTrans,
                 nelem_per_row, ncols, 1., Asub, ncols, 
                 rrow, 1, 0, bsub, 1);
 

--- a/mathtools/matrix_helper.cpp
+++ b/mathtools/matrix_helper.cpp
@@ -607,10 +607,7 @@ namespace mxhelp
     double OversampledMatrix::getBufMemUsage()
     {
         // Convert to MB by division of 1048576
-        double highressize  = (double)sizeof(double) * ncols * (ncols+1) / 1048576.,
-               sandwichsize = (double)sizeof(double) * nrows * ncols / 1048576.;
-
-        return highressize+sandwichsize;
+        return (double)sizeof(double) * nrows * ncols / 1048576.;
     }
 
     void OversampledMatrix::fprintfMatrix(const char *fname)

--- a/mathtools/matrix_helper.hpp
+++ b/mathtools/matrix_helper.hpp
@@ -96,12 +96,14 @@ namespace mxhelp
         void orderTranspose();
 
         // B initialized to zero
-        // SIDE = 'L' or 'l',   B = op( R ) . A,
-        // SIDE = 'R' or 'r',   B = A . op( R ).
-        // TRANSR = 'N' or 'n',  op( R ) = R.
-        // TRANSR = 'T' or 't',  op( R ) = R^T.
-        void multiply(char SIDER, char TRANSR, const double* A, double *B);
-        void multiplyLeft(char TRANS_A, const double* A, double *B);
+        // SIDE = CblasLeft,    B = op( R ) . A,
+        // SIDE = CblasRight,   B = A . op( R ).
+        // TRANSR = CblasNoTrans,  op( R ) = R.
+        // TRANSR = CblasTrans,    op( R ) = R^T.
+        void multiply(
+            CBLAS_SIDE SIDER, CBLAS_TRANSPOSE TRANSR,
+            const double* A, double *B);
+        void multiplyLeft(CBLAS_TRANSPOSE TRANS_A, const double* A, double *B);
 
         // R . inplace . R^T
         void sandwich(double *inplace);

--- a/mathtools/matrix_helper.hpp
+++ b/mathtools/matrix_helper.hpp
@@ -103,7 +103,8 @@ namespace mxhelp
         void multiply(
             CBLAS_SIDE SIDER, CBLAS_TRANSPOSE TRANSR,
             const double* A, double *B);
-        void multiplyLeft(CBLAS_TRANSPOSE TRANS_A, const double* A, double *B);
+        void multiplyLeft(const double* A, double *B);
+        void multiplyRightT(const double* A, double *B);
 
         // R . inplace . R^T
         void sandwich(double *inplace);

--- a/mathtools/matrix_helper.hpp
+++ b/mathtools/matrix_helper.hpp
@@ -101,6 +101,7 @@ namespace mxhelp
         // TRANSR = 'N' or 'n',  op( R ) = R.
         // TRANSR = 'T' or 't',  op( R ) = R^T.
         void multiply(char SIDER, char TRANSR, const double* A, double *B);
+        void multiplyLeft(char TRANS_A, const double* A, double *B);
 
         // R . inplace . R^T
         void sandwich(double *inplace);

--- a/tests/cblas_tests.cpp
+++ b/tests/cblas_tests.cpp
@@ -451,17 +451,27 @@ truth_diamatrix_Tl_multiplication[] = {
     -59,  -64,  -73,    8,   21,  -25,   64};
 
 const std::unordered_map<std::string, const double*>
-diamatrix_truth_map ({
-    {"LN", truth_diamatrix_LN_multiplication},
-    {"LT", truth_diamatrix_LT_multiplication},
-    {"RN", truth_diamatrix_RN_multiplication},
-    {"RT", truth_diamatrix_RT_multiplication},
-    {"Nl", truth_diamatrix_LN_multiplication},
-    {"Tl", truth_diamatrix_Tl_multiplication}
-});
+    diamatrix_truth_map ({
+        {"LN", truth_diamatrix_LN_multiplication},
+        {"LT", truth_diamatrix_LT_multiplication},
+        {"RN", truth_diamatrix_RN_multiplication},
+        {"RT", truth_diamatrix_RT_multiplication},
+        {"Nl", truth_diamatrix_LN_multiplication},
+        {"Tl", truth_diamatrix_Tl_multiplication}
+    });
 
-int _compare_one_DiaMatrix_multiplications(const std::string &combo, const double* result)
-{
+const std::unordered_map<char, CBLAS_SIDE>
+    char2side ({
+        {'L', CblasLeft}, {'R', CblasRight}
+    });
+
+const std::unordered_map<char, CBLAS_TRANSPOSE>
+    char2trans ({
+        {'N', CblasNoTrans}, {'T', CblasTrans}
+    });
+
+int _compare_one_DiaMatrix_multiplications(
+        const std::string &combo, const double* result) {
     int r = 0;
     const double *truth = diamatrix_truth_map.at(combo);
     if (not allClose(truth, result, NrowsDiag*NrowsDiag))
@@ -487,7 +497,10 @@ int test_DiaMatrix_multiplications()
     const std::vector<std::string> combos {"LN", "LT", "RN", "RT"};
     for (const auto &combo: combos)
     {
-        diarmat.multiply(combo[0], combo[1], diamatrix_multiplier_B, result_R.data());
+        diarmat.multiply(
+            char2side.at(combo[0]),
+            char2trans.at(combo[1]),
+            diamatrix_multiplier_B, result_R.data());
         r += _compare_one_DiaMatrix_multiplications(combo, result_R.data());
     }
 
@@ -508,7 +521,9 @@ int test_DiaMatrix_multipyLeft()
     const std::vector<std::string> combos {"Nl", "Tl"};
     for (const auto &combo: combos)
     {
-        diarmat.multiplyLeft(combo[0], diamatrix_multiplier_B, result_R.data());
+        diarmat.multiplyLeft(
+            char2trans.at(combo[0]),
+            diamatrix_multiplier_B, result_R.data());
         r += _compare_one_DiaMatrix_multiplications(combo, result_R.data());
     }
     return r;

--- a/tests/cblas_tests.cpp
+++ b/tests/cblas_tests.cpp
@@ -518,12 +518,30 @@ int test_DiaMatrix_multipyLeft()
         diarmat.matrix()
     );
 
-    const std::vector<std::string> combos {"Nl", "Tl"};
+    const std::vector<std::string> combos {"Nl"};
     for (const auto &combo: combos)
     {
-        diarmat.multiplyLeft(
-            char2trans.at(combo[0]),
-            diamatrix_multiplier_B, result_R.data());
+        diarmat.multiplyLeft(diamatrix_multiplier_B, result_R.data());
+        r += _compare_one_DiaMatrix_multiplications(combo, result_R.data());
+    }
+    return r;
+}
+
+int test_DiaMatrix_multiplyRightT()
+{
+    int r = 0;
+    std::vector<double> result_R(NrowsDiag*NrowsDiag, 0);
+    mxhelp::DiaMatrix diarmat(NrowsDiag, NdiagDiag);
+    std::copy(
+        &diamatrix_diagonals[0],
+        &diamatrix_diagonals[0]+NrowsDiag*NdiagDiag,
+        diarmat.matrix()
+    );
+
+    const std::vector<std::string> combos {"RT"};
+    for (const auto &combo: combos)
+    {
+        diarmat.multiplyRightT(diamatrix_multiplier_B, result_R.data());
         r += _compare_one_DiaMatrix_multiplications(combo, result_R.data());
     }
     return r;
@@ -616,6 +634,7 @@ int main()
     r += test_OversampledMatrix_multiplications();
     r += test_DiaMatrix_multiplications();
     r += test_DiaMatrix_multipyLeft();
+    r += test_DiaMatrix_multiplyRightT();
     r += test_DiaMatrix_getRow();
     r += test_LAPACKE_SVD();
     r += test_Resolution_osamp();

--- a/tests/cblas_tests.cpp
+++ b/tests/cblas_tests.cpp
@@ -380,11 +380,11 @@ int test_OversampledMatrix_multiplications()
 #define NdiagDiag 5
 const double
 diamatrix_diagonals[] = {
-    -1, -1, 5, 2, 7, 7, 4,
-   -1,  4, 1, 7, 2, 4, 3,
-    1,  8, 1, 3, 7, 4, 4,
-    2,  4, 1, 7, 1, 4, -1,
-    9, 1, 1, 2, 7, -1, -1},
+    0, 0, 5, 2, 7, 7, 4,
+    0, 4, 1, 7, 2, 4, 3,
+    1, 8, 1, 3, 7, 4, 4,
+    2, 4, 1, 7, 1, 4, 0,
+    9, 1, 1, 2, 7, 0, 0},
 diamatrix_rows[] = {
     5, 4, 1, 4, 5,
        2, 2, 8, 1, 2,
@@ -401,6 +401,14 @@ diamatrix_multiplier_B[] = {
     1, 2, -5, 7, -1, 6, 1, 
     3, -7, 0, 9, 1, -6, -2, 
     -3, 5, 9, -6, 4, 1, 8},
+diamatrix_multiplier_Sym[] = {
+    -2, -5,  5,  3,  8,  5, -5,
+    -5, -4, -3, 11,  2, -1,  9,
+     5, -3, -4,  1,  5,  9,  5,
+     3, 11,  1,  2,  9,  0,  3,
+     8,  2,  5,  9,  6,  7,  9,
+     5, -1,  9,  0,  7, -6,  9,
+    -5,  9,  5,  3,  9,  9,  0},
 truth_diamatrix_LN_multiplication[] = {
     2.50e+01, -2.00e+00, 4.80e+01, -3.10e+01, -2.00e+01, -8.30e+01, -5.20e+01, 
     2.00e+00, -5.40e+01, 5.90e+01, -1.20e+01, 3.00e+00, -1.01e+02, -7.60e+01, 
@@ -432,14 +440,24 @@ truth_diamatrix_RT_multiplication[] = {
     3.10e+01, 2.20e+01, 8.10e+01, -4.00e+01, -2.00e+00, -4.00e+01, 8.00e+00, 
     -1.60e+01, 2.70e+01, 5.40e+01, 5.80e+01, 6.50e+01, 4.00e+01, 2.10e+01, 
     -2.50e+01, -3.20e+01, 6.90e+01, -2.00e+01, 3.80e+01, -1.10e+01, -2.50e+01, 
-    6.20e+01, 3.10e+01, -1.20e+01, 1.10e+01, 3.10e+01, 2.00e+01, 6.40e+01};
+    6.20e+01, 3.10e+01, -1.20e+01, 1.10e+01, 3.10e+01, 2.00e+01, 6.40e+01},
+truth_diamatrix_Tl_multiplication[] = {
+     22,  -10,   55,   31,  -16,  -25,   62,
+     -5,  -60,   53,   22,   27,  -32,   31,
+     32,  -56,   20,   81,   54,   69,  -12,
+      0,  -72,  -76,  -40,   58,  -20,   11,
+     -3,  -74, -110,   -2,   65,   38,   31,
+    -11,  -61,  -63,  -40,   40,  -11,   20,
+    -59,  -64,  -73,    8,   21,  -25,   64};
 
 const std::unordered_map<std::string, const double*>
 diamatrix_truth_map ({
     {"LN", truth_diamatrix_LN_multiplication},
     {"LT", truth_diamatrix_LT_multiplication},
     {"RN", truth_diamatrix_RN_multiplication},
-    {"RT", truth_diamatrix_RT_multiplication}
+    {"RT", truth_diamatrix_RT_multiplication},
+    {"Nl", truth_diamatrix_LN_multiplication},
+    {"Tl", truth_diamatrix_Tl_multiplication}
 });
 
 int _compare_one_DiaMatrix_multiplications(const std::string &combo, const double* result)
@@ -473,6 +491,26 @@ int test_DiaMatrix_multiplications()
         r += _compare_one_DiaMatrix_multiplications(combo, result_R.data());
     }
 
+    return r;
+}
+
+int test_DiaMatrix_multipyLeft()
+{
+    int r = 0;
+    std::vector<double> result_R(NrowsDiag*NrowsDiag, 0);
+    mxhelp::DiaMatrix diarmat(NrowsDiag, NdiagDiag);
+    std::copy(
+        &diamatrix_diagonals[0],
+        &diamatrix_diagonals[0]+NrowsDiag*NdiagDiag,
+        diarmat.matrix()
+    );
+
+    const std::vector<std::string> combos {"Nl", "Tl"};
+    for (const auto &combo: combos)
+    {
+        diarmat.multiplyLeft(combo[0], diamatrix_multiplier_B, result_R.data());
+        r += _compare_one_DiaMatrix_multiplications(combo, result_R.data());
+    }
     return r;
 }
 
@@ -562,6 +600,7 @@ int main()
     r += test_LAPACKE_InvertMatrixLU_2();
     r += test_OversampledMatrix_multiplications();
     r += test_DiaMatrix_multiplications();
+    r += test_DiaMatrix_multipyLeft();
     r += test_DiaMatrix_getRow();
     r += test_LAPACKE_SVD();
     r += test_Resolution_osamp();

--- a/tests/testSQCMatrices.cpp
+++ b/tests/testSQCMatrices.cpp
@@ -32,6 +32,7 @@ public:
         chunks[0]->_allocateMatrices();
         process::sq_private_table->readSQforR(chunks[0]->RES_INDEX, 
             chunks[0]->interp2d_signal_matrix, chunks[0]->interp_derivative_matrix);
+        chunks[0]->_setVZMatrices();
     };
 
     ~TestOneQSOEstimate() { chunks[0]->_freeMatrices(); };


### PR DESCRIPTION
This branch brings in storing velocity and redshift matrices to simplify setQi and setSfid functions. It also brings OpenMP support and uses it in those functions.

Minor speed ups: 
+ fisher matrix is calculated on the upper triangle. It is copied after summation and multiplied by 0.5.
+ DiscreteInterpolator works with int instead of long. Clipping done on integer index instead of double.