### PR TITLE
Static OpenMP scheduling when marginalization

### DIFF
--- a/qu3d/cosmic_quasar.hpp
+++ b/qu3d/cosmic_quasar.hpp
@@ -209,8 +209,9 @@ public:
     }
 
     void setInIsigWithMarg() {
+        // assert(fidx == myomp::getThreadNum());
         double *rrmat = GL_RMAT[myomp::getThreadNum()].get();
-        ioh::continuumMargFileHandler->read(fidx, fpos, N, rrmat);
+        ioh::continuumMargFileHandler->read(fpos, N, rrmat);
         cblas_dsymv(CblasRowMajor, CblasUpper, N, 1.0,
                     rrmat, N, in, 1, 0, in_isig, 1);
 
@@ -219,8 +220,9 @@ public:
     }
 
     void multTruthWithMarg() {
+        // assert(fidx == myomp::getThreadNum());
         double *rrmat = GL_RMAT[myomp::getThreadNum()].get();
-        ioh::continuumMargFileHandler->read(fidx, fpos, N, rrmat);
+        ioh::continuumMargFileHandler->read(fpos, N, rrmat);
         cblas_dsymv(CblasRowMajor, CblasUpper, N, 1.0,
                     rrmat, N, truth, 1, 0, in_isig, 1);
 
@@ -518,8 +520,8 @@ public:
                 Emat[b + a * nvecs] = cblas_ddot(
                     N, uvecs[a].get(), 1, uvecs[b].get(), 1);
 
-                if (a == b)
-                    assert(fabs(Emat[a * (1 + nvecs)] - 1) < DOUBLE_EPSILON);
+                // if (a == b)
+                // assert(fabs(Emat[a * (1 + nvecs)] - 1.0) < DOUBLE_EPSILON);
             }
         }
 

--- a/qu3d/optimal_qu3d_mc.cpp
+++ b/qu3d/optimal_qu3d_mc.cpp
@@ -328,6 +328,7 @@ void Qu3DEstimator::testHSqrt() {
         column_types, nullptr, "HSQRT", &status);
     ioh::checkFitsStatus(status);
 
+    auto xTx_arr = std::make_unique<double[]>(max_monte_carlos);
     auto yTy_arr = std::make_unique<double[]>(max_monte_carlos);
     auto xTHx_arr = std::make_unique<double[]>(max_monte_carlos);
 
@@ -353,7 +354,7 @@ void Qu3DEstimator::testHSqrt() {
         for (auto &qso : quasars)
             yTy += cblas_ddot(qso->N, qso->truth, 1, qso->truth, 1);
 
-        xTHx_arr[i - 1] = xTHx / xTx;  yTy_arr[i - 1] = yTy / xTx;
+        xTx_arr[i - 1] = xTx;  xTHx_arr[i - 1] = xTHx;  yTy_arr[i - 1] = yTy;
         ++prog_tracker;
 
         verbose = false;
@@ -364,6 +365,8 @@ void Qu3DEstimator::testHSqrt() {
         fits_write_col(fits_file, TDOUBLE, 1, irow + 1, 1, nelems, xTHx_arr.get() + irow,
                        &status);
         fits_write_col(fits_file, TDOUBLE, 2, irow + 1, 1, nelems, yTy_arr.get() + irow,
+                       &status);
+        fits_write_col(fits_file, TDOUBLE, 3, irow + 1, 1, nelems, xTx_arr.get() + irow,
                        &status);
         fits_flush_buffer(fits_file, 0, &status);
         ioh::checkFitsStatus(status);


### PR DESCRIPTION
Static scheduling guarantees each thread reads one file and reads it sequentially