### PR TITLE
Ensure maximum length and mean pixel size for each segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,11 @@ Other params
 + `MaximumForestLength` (double, default: 3.5e4):
     Maximum length of the forest to use in dynamic chunking. Accurate
     values enable a consistent maximum length of each chunk. The max
-    forest length of each chunk will be this / `DynamicChunkNumber`.
+    forest length of each chunk will be this / `DynamicChunkNumber`. This helps
+    to stabilize the large-scale modes.
++ `MaximumMeanPixelSize` (double, default: 150.0):
+    Maximum mean pixel size. This helps to stabilize the modes near the
+    Nyquist by eliminating sparsely sampled chunks.
 + `TurnOffBaseline` (int):
     Turns off the fiducial signal matrix if > 0. Fid is on by default.
 + `SmoothLnkLnP` (int):

--- a/README.md
+++ b/README.md
@@ -218,6 +218,10 @@ Other params
     per chunk.
 + `DynamicChunkNumber` (int):
     Dynamiccaly chunk spectra into this number when > 1. Off by default.
++ `MaximumForestLength` (double, default: 3.5e4):
+    Maximum length of the forest to use in dynamic chunking. Accurate
+    values enable a consistent maximum length of each chunk. The max
+    forest length of each chunk will be this / `DynamicChunkNumber`.
 + `TurnOffBaseline` (int):
     Turns off the fiducial signal matrix if > 0. Fid is on by default.
 + `SmoothLnkLnP` (int):

--- a/core/chunk_estimate.cpp
+++ b/core/chunk_estimate.cpp
@@ -170,14 +170,16 @@ void Chunk::_copyQSOFile(const qio::QSOFile &qmaster, int i1, int i2)
 {
     qFile = std::make_unique<qio::QSOFile>(qmaster, i1, i2);
 
-    if (qFile->realSize() < MIN_PIXELS_IN_CHUNK || qFile->getLengthV() < specifics::MIN_FOREST_LENGTH_V)
+    double lenv = qFile->getLengthV(), meandv = lenv / qFile->realSize();
+    if (meandv > specifics::MAX_PIXEL_LENGTH_V || lenv < specifics::MIN_FOREST_LENGTH_V)
     {
         std::ostringstream err_msg;
         err_msg.precision(1);
         err_msg << "Short chunk with realsize "
             << qFile->realSize() << '/'  << qFile->size() << " and velocity length "
             << std::scientific
-            << qFile->getLengthV() << '/'  << specifics::MIN_FOREST_LENGTH_V;
+            << lenv << '/'  << specifics::MIN_FOREST_LENGTH_V
+            << " || mean dv: " << meandv << '/'  << specifics::MAX_PIXEL_LENGTH_V;
 
         throw std::runtime_error(err_msg.str());
     }
@@ -295,10 +297,9 @@ double Chunk::getComputeTimeEst(const qio::QSOFile &qmaster, int i1, int i2)
     try
     {
         qio::QSOFile qtemp(qmaster, i1, i2);
-        if (qtemp.realSize() < MIN_PIXELS_IN_CHUNK)
-            return 0;
 
-        if (qtemp.getLengthV() < specifics::MIN_FOREST_LENGTH_V)
+        double lenv = qtemp.getLengthV(), meandv = lenv / qtemp.realSize();
+        if (meandv > specifics::MAX_PIXEL_LENGTH_V || lenv < specifics::MIN_FOREST_LENGTH_V)
             return 0;
 
         double z1, z2, zm; 

--- a/core/chunk_estimate.cpp
+++ b/core/chunk_estimate.cpp
@@ -170,11 +170,14 @@ void Chunk::_copyQSOFile(const qio::QSOFile &qmaster, int i1, int i2)
 {
     qFile = std::make_unique<qio::QSOFile>(qmaster, i1, i2);
 
-    if (qFile->realSize() < MIN_PIXELS_IN_CHUNK)
+    if (qFile->realSize() < MIN_PIXELS_IN_CHUNK || qFile->getLengthV() < specifics::MIN_FOREST_LENGTH_V)
     {
         std::ostringstream err_msg;
+        err_msg.precision(1);
         err_msg << "Short chunk with realsize "
-            << qFile->realSize() << '/'  << qFile->size() << '.';
+            << qFile->realSize() << '/'  << qFile->size() << " and velocity length "
+            << std::scientific
+            << qFile->getLengthV() << '/'  << specifics::MIN_FOREST_LENGTH_V;
 
         throw std::runtime_error(err_msg.str());
     }
@@ -293,6 +296,9 @@ double Chunk::getComputeTimeEst(const qio::QSOFile &qmaster, int i1, int i2)
     {
         qio::QSOFile qtemp(qmaster, i1, i2);
         if (qtemp.realSize() < MIN_PIXELS_IN_CHUNK)
+            return 0;
+
+        if (qtemp.getLengthV() < specifics::MIN_FOREST_LENGTH_V)
             return 0;
 
         double z1, z2, zm; 

--- a/core/chunk_estimate.hpp
+++ b/core/chunk_estimate.hpp
@@ -5,8 +5,6 @@
 #include "io/qso_file.hpp"
 #include "mathtools/discrete_interpolation.hpp"
 
-const int MIN_PIXELS_IN_CHUNK = 100;
-
 /*
 This object creates and computes C, S, Q, Q-slash matrices,
 as well as a power spectrum estimate and a fisher matrix for individual 

--- a/core/chunk_estimate.hpp
+++ b/core/chunk_estimate.hpp
@@ -5,8 +5,7 @@
 #include "io/qso_file.hpp"
 #include "mathtools/discrete_interpolation.hpp"
 
-const int
-MIN_PIXELS_IN_CHUNK = 40;
+const int MIN_PIXELS_IN_CHUNK = 100;
 
 /*
 This object creates and computes C, S, Q, Q-slash matrices,

--- a/core/global_numbers.cpp
+++ b/core/global_numbers.cpp
@@ -69,7 +69,8 @@ namespace specifics
          SAVE_BOOTREALIZATIONS;
     int CONT_LOGLAM_MARG_ORDER = 1, CONT_LAM_MARG_ORDER = 1, 
         CONT_NVECS = 3, NUMBER_OF_CHUNKS = 1, NUMBER_OF_BOOTS = 0;
-    double RESOMAT_DECONVOLUTION_M = 0, MIN_SNR_CUT = 0;
+    double RESOMAT_DECONVOLUTION_M = 0, MIN_SNR_CUT = 0,
+           MAX_FOREST_LENGTH_V = 0, MIN_FOREST_LENGTH_V = 0;
     qio::ifileformat INPUT_QSO_FILE = qio::Binary;
     int OVERSAMPLING_FACTOR = -1;
 
@@ -97,8 +98,12 @@ namespace specifics
         MIN_SNR_CUT = config.getDouble("MinimumSnrCut");
         RESOMAT_DECONVOLUTION_M = config.getDouble("ResoMatDeconvolutionM");
         OVERSAMPLING_FACTOR = config.getInteger("OversampleRmat", -1);
-        NUMBER_OF_CHUNKS = config.getInteger("DynamicChunkNumber", 1);
+        NUMBER_OF_CHUNKS = std::max(1, config.getInteger("DynamicChunkNumber", 1));
         NUMBER_OF_BOOTS = config.getInteger("NumberOfBoots");
+
+        MAX_FOREST_LENGTH_V = config.getDouble("MaximumForestLength", 3.5e4);
+        MAX_FOREST_LENGTH_V /= NUMBER_OF_CHUNKS;
+        MIN_FOREST_LENGTH_V = 0.95 / 2 * MAX_FOREST_LENGTH_V;
 
         double temp_chisq = config.getDouble("ChiSqConvergence");
         if (temp_chisq > 0)
@@ -144,6 +149,10 @@ namespace specifics
             OVERSAMPLING_FACTOR);
         LOG::LOGGER.STD("DynamicChunkNumber is set to %d.\n",
             NUMBER_OF_CHUNKS);
+        LOG::LOGGER.STD("Maximum chunk length is set to %.2e.\n",
+            MAX_FOREST_LENGTH_V);
+        LOG::LOGGER.STD("Minimum chunk length is set to %.2e.\n",
+            MIN_FOREST_LENGTH_V);
         LOG::LOGGER.STD("Fiducial signal matrix is set to turned %s.\n",
             TURN_OFF_SFID ? "OFF" : "ON");
         LOG::LOGGER.STD("SmoothLnkLnP is set to %s.\n",

--- a/core/global_numbers.cpp
+++ b/core/global_numbers.cpp
@@ -70,7 +70,8 @@ namespace specifics
     int CONT_LOGLAM_MARG_ORDER = 1, CONT_LAM_MARG_ORDER = 1, 
         CONT_NVECS = 3, NUMBER_OF_CHUNKS = 1, NUMBER_OF_BOOTS = 0;
     double RESOMAT_DECONVOLUTION_M = 0, MIN_SNR_CUT = 0,
-           MAX_FOREST_LENGTH_V = 0, MIN_FOREST_LENGTH_V = 0;
+           MAX_FOREST_LENGTH_V = 0, MIN_FOREST_LENGTH_V = 0,
+           MAX_PIXEL_LENGTH_V = 0;
     qio::ifileformat INPUT_QSO_FILE = qio::Binary;
     int OVERSAMPLING_FACTOR = -1;
 
@@ -103,7 +104,8 @@ namespace specifics
 
         MAX_FOREST_LENGTH_V = config.getDouble("MaximumForestLength", 3.5e4);
         MAX_FOREST_LENGTH_V /= NUMBER_OF_CHUNKS;
-        MIN_FOREST_LENGTH_V = 0.95 / 2 * MAX_FOREST_LENGTH_V;
+        MIN_FOREST_LENGTH_V = 0.90 / 2 * MAX_FOREST_LENGTH_V;
+        MAX_PIXEL_LENGTH_V = config.getDouble("MaximumMeanPixelSize", 120.0);
 
         double temp_chisq = config.getDouble("ChiSqConvergence");
         if (temp_chisq > 0)

--- a/core/global_numbers.hpp
+++ b/core/global_numbers.hpp
@@ -83,14 +83,15 @@ namespace specifics
     extern double RESOMAT_DECONVOLUTION_M, MIN_SNR_CUT;
     extern qio::ifileformat INPUT_QSO_FILE;
 
-    extern double MAX_FOREST_LENGTH_V, MIN_FOREST_LENGTH_V;
+    extern double MAX_FOREST_LENGTH_V, MIN_FOREST_LENGTH_V, MAX_PIXEL_LENGTH_V;
 
     const config_map specifics_default_parameters ({
         {"MinimumSnrCut", "0"}, {"InputIsPicca", "-1"}, {"UseResoMatrix", "-1"},
         {"ResoMatDeconvolutionM", "-1"}, {"OversampleRmat", "-1"},
         {"DynamicChunkNumber", "1"}, {"TurnOffBaseline", "-1"},
         {"SmoothLnkLnP", "1"}, {"ChiSqConvergence", "1e-2"},
-        {"RedshiftGrowthOn", "-1"}, {"MaximumForestLength", "3.5e4"},
+        {"RedshiftGrowthOn", "-1"},
+        {"MaximumForestLength", "3.5e4"}, {"MaximumMeanPixelSize", "150.0"},
         {"ContinuumLogLambdaMargOrder", "1"}, {"ContinuumLambdaMargOrder", "-1"},
         {"PrecomputedFisher", ""}, {"Targetids2Ignore", ""},
         {"NumberOfBoots", "20000"}, {"FastBootstrap", "1"},
@@ -126,6 +127,9 @@ namespace specifics
         Maximum length of the forest to use in dynamic chunking. Accurate
         values enable a consistent maximum length of each chunk. The max
         forest length of each chunk will be this / DynamicChunkNumber.
+    MaximumMeanPixelSize: double, default: 150.0
+        Maximum mean pixel size. This helps to stabilize the modes near the
+        Nyquist by eliminating sparsely sampled chunks.
     ContinuumLogLambdaMargOrder: int
         Polynomial order for log lambda cont marginalization. Default 1.
     ContinuumLambdaMargOrder: int

--- a/core/global_numbers.hpp
+++ b/core/global_numbers.hpp
@@ -83,12 +83,14 @@ namespace specifics
     extern double RESOMAT_DECONVOLUTION_M, MIN_SNR_CUT;
     extern qio::ifileformat INPUT_QSO_FILE;
 
+    extern double MAX_FOREST_LENGTH_V, MIN_FOREST_LENGTH_V;
+
     const config_map specifics_default_parameters ({
         {"MinimumSnrCut", "0"}, {"InputIsPicca", "-1"}, {"UseResoMatrix", "-1"},
         {"ResoMatDeconvolutionM", "-1"}, {"OversampleRmat", "-1"},
         {"DynamicChunkNumber", "1"}, {"TurnOffBaseline", "-1"},
         {"SmoothLnkLnP", "1"}, {"ChiSqConvergence", "1e-2"},
-        {"RedshiftGrowthOn", "-1"},
+        {"RedshiftGrowthOn", "-1"}, {"MaximumForestLength", "3.5e4"},
         {"ContinuumLogLambdaMargOrder", "1"}, {"ContinuumLambdaMargOrder", "-1"},
         {"PrecomputedFisher", ""}, {"Targetids2Ignore", ""},
         {"NumberOfBoots", "20000"}, {"FastBootstrap", "1"},
@@ -120,6 +122,10 @@ namespace specifics
         Criteria for chi square convergance. Valid when > 0. Default is 1e-2
     RedshiftGrowthOn: int, default: -1
         Multiply derivative matrices with a power scaling of redshift.
+    MaximumForestLength: double, default: 3.5e4
+        Maximum length of the forest to use in dynamic chunking. Accurate
+        values enable a consistent maximum length of each chunk. The max
+        forest length of each chunk will be this / DynamicChunkNumber.
     ContinuumLogLambdaMargOrder: int
         Polynomial order for log lambda cont marginalization. Default 1.
     ContinuumLambdaMargOrder: int

--- a/core/one_qso_estimate.cpp
+++ b/core/one_qso_estimate.cpp
@@ -11,21 +11,38 @@
 
 #include <stdexcept>
 
-const int
-MAX_PIXELS_IN_FOREST = 700;
 
-std::vector<int> OneQSOEstimate::decideIndices(int size) {
+std::vector<int> OneQSOEstimate::decideIndices(int size, double *wave) {
     int nchunks = 1;
+    auto velarr = std::make_unique<double[]>(size);
+    double wave0 = wave[0];
+    std::transform(
+        wave, wave + size, velarr.get(),
+        [&wave0](const double &w) { return SPEED_OF_LIGHT * log(w / wave0); });
+    double vmax = velarr[size - 1];
+
     if (specifics::NUMBER_OF_CHUNKS > 1) {
-        nchunks += (specifics::NUMBER_OF_CHUNKS * size) / MAX_PIXELS_IN_FOREST;
-        nchunks = std::min(nchunks, specifics::NUMBER_OF_CHUNKS);
+        nchunks += vmax / specifics::MAX_FOREST_LENGTH_V;
+        // nchunks = std::min(nchunks, specifics::NUMBER_OF_CHUNKS);
+        // nchunks can be greater than specifics::NUMBER_OF_CHUNKS to
+        // achieve consistent velocity lengths. However, this should not
+        // happen if specifics::MAX_FOREST_LENGTH_V > vmax for all spectra.
+
+        vmax = std::min(specifics::MAX_FOREST_LENGTH_V, vmax / nchunks);
     }
 
     std::vector<int> indices;
     indices.reserve(nchunks + 1);
-    for (int i = 0; i < nchunks; ++i)
-        indices.push_back((int)((size * i) / nchunks));
-    indices.push_back(size);
+    indices.push_back(0);
+    double *v1 = velarr.get(), *v2 = v1 + size, *vl = v1;
+    for (int i = 0; i < nchunks; ++i) {
+        int jj = std::upper_bound(vl, v2, vmax) - v1;
+        indices.push_back(jj);
+        if (jj == size)  break;
+        vl = v1 + jj;
+        double vl0 = *vl;
+        std::for_each(vl, v2, [&vl0](double &v) { v -= vl0; });
+    }
 
     return indices;
 }
@@ -87,7 +104,8 @@ OneQSOEstimate::OneQSOEstimate(const std::string &f_qso)
         auto qFile = _readQsoFile(f_qso);
 
         // decide nchunk with lambda points array[nchunks+1]
-        std::vector<int> indices = OneQSOEstimate::decideIndices(qFile->size());
+        std::vector<int> indices = OneQSOEstimate::decideIndices(
+            qFile->size(), qFile->wave());
         int nchunks = indices.size() - 1;
 
         // create chunk objects
@@ -134,7 +152,8 @@ double OneQSOEstimate::getComputeTimeEst(std::string fname_qso, int &zbin, long 
         zbin = bins::findRedshiftBin(zm);
 
         // decide chunks
-        std::vector<int> indices = OneQSOEstimate::decideIndices(qtemp.size());
+        std::vector<int> indices = OneQSOEstimate::decideIndices(
+            qtemp.size(), qtemp.wave());
         int nchunks = indices.size() - 1;
 
         // add compute time from chunks

--- a/core/one_qso_estimate.cpp
+++ b/core/one_qso_estimate.cpp
@@ -11,6 +11,8 @@
 
 #include <stdexcept>
 
+const int MIN_PIXELS_IN_FILE = 100;
+
 
 std::vector<int> OneQSOEstimate::decideIndices(int size, double *wave) {
     int nchunks = 1;
@@ -91,7 +93,7 @@ std::unique_ptr<qio::QSOFile> OneQSOEstimate::_readQsoFile(const std::string &f_
     // Boundary cut
     qFile->cutBoundary(bins::Z_LOWER_EDGE, bins::Z_UPPER_EDGE);
 
-    if (qFile->realSize() < MIN_PIXELS_IN_CHUNK)
+    if (qFile->realSize() < MIN_PIXELS_IN_FILE)
         throw std::runtime_error("OneQSOEstimate::_readQsoFile::Short file");
 
     return qFile;
@@ -144,7 +146,7 @@ double OneQSOEstimate::getComputeTimeEst(std::string fname_qso, int &zbin, long 
         qtemp.readData();
         qtemp.cutBoundary(bins::Z_LOWER_EDGE, bins::Z_UPPER_EDGE);
 
-        if (qtemp.realSize() < MIN_PIXELS_IN_CHUNK)
+        if (qtemp.realSize() < MIN_PIXELS_IN_FILE)
             return 0;
 
         double z1, z2, zm;

--- a/core/one_qso_estimate.hpp
+++ b/core/one_qso_estimate.hpp
@@ -30,7 +30,7 @@ public:
     OneQSOEstimate(OneQSOEstimate &&rhs) = default;
     OneQSOEstimate(const OneQSOEstimate &rhs) = delete;
 
-    static std::vector<int> decideIndices(int size);
+    static std::vector<int> decideIndices(int size, double *wave);
     static double getComputeTimeEst(std::string fname_qso, int &zbin, long &targetid);
 
     // Pass fit values for the power spectrum for numerical stability

--- a/cross/one_qso_exposures.cpp
+++ b/cross/one_qso_exposures.cpp
@@ -241,7 +241,8 @@ OneQsoExposures::OneQsoExposures(const std::string &f_qso) : OneQSOEstimate() {
         dec = qFile->dec;
 
         exposures.reserve(30);
-        std::vector<int> indices = OneQSOEstimate::decideIndices(qFile->size());
+        std::vector<int> indices = OneQSOEstimate::decideIndices(
+            qFile->size(), qFile->wave());
         int nchunks = indices.size() - 1;
 
         for (int nc = 0; nc < nchunks; ++nc) {

--- a/io/qso_file.hpp
+++ b/io/qso_file.hpp
@@ -137,6 +137,9 @@ public:
 
     int size() const { return arr_size; };
     int realSize() const { return arr_size-num_masked_pixels; };
+    double getLengthV() const {
+        return SPEED_OF_LIGHT * log(wave()[arr_size - 1] / wave()[0]);
+    }
     double* wave() const  { return wave_head+shift; };
     double* delta() const { return delta_head+shift; };
     double* ivar() const { return ivar_head+shift; };

--- a/tests/input/test.config
+++ b/tests/input/test.config
@@ -19,6 +19,7 @@ NumberOfRedshiftBins 2
 # The location of the file list, and the directory where those files live:
 FileNameList ./tests/input/flist.txt
 FileInputDir ./tests/input/
+MaximumForestLength 14000.0
 
 # The directory for output files and file name base:
 OutputDir ./tests/output/


### PR DESCRIPTION
This PR adds new options to the config file: `MaximumForestLength` and `MaximumMeanPixelSize`. These are used to ensure each chunk has a maximum length according to the input number of chunks argument and a minimum number of pixels that satisfy the maximum mean pixel size argument. The chunks are further eliminated to have a minimum length to stabilize estimates at the largest scales.