### PR TITLE
Better preconditioner when continuum is marginalized

### DIFF
--- a/qu3d/contmarg_file.hpp
+++ b/qu3d/contmarg_file.hpp
@@ -60,6 +60,7 @@ namespace ioh {
         }
 
         void closeAllWriters() { file_writers.clear(); }
+        void closeAllReaders() { file_readers.clear(); }
 
         void rewind() {
             for (auto &fptr : file_readers)

--- a/qu3d/cosmic_quasar.hpp
+++ b/qu3d/cosmic_quasar.hpp
@@ -35,6 +35,7 @@ struct CompareCosmicQuasarPtr {
     }
 };
 
+#define myQsoDot(Q, X, Y) cblas_ddot(Q->N, Q->X, 1, Q->Y, 1);
 
 class CosmicQuasar {
 private:

--- a/qu3d/cosmic_quasar.hpp
+++ b/qu3d/cosmic_quasar.hpp
@@ -411,7 +411,7 @@ public:
         if (cmarg) {
             double di = small_scale ? alpha - 1.0 / s : 1.0;
             for (int i = 0; i < N; ++i)
-                ccov[(i + 1) * N] -= di;
+                ccov[(N + 1) * i] -= di;
             mxhelp::copyUpperToLower(ccov, N);
             mxhelp::copyUpperToLower(_rrmat.get(), N);
 
@@ -427,7 +427,7 @@ public:
                 0, ccov, N);
 
             for (int i = 0; i < N; ++i)
-                ccov[(i + 1) * N] += di;
+                ccov[(N + 1) * i] += di;
         }
 
         lapack_int info = LAPACKE_dpotrf(LAPACK_ROW_MAJOR, 'U', N, ccov, N);

--- a/qu3d/cosmic_quasar.hpp
+++ b/qu3d/cosmic_quasar.hpp
@@ -39,7 +39,6 @@ struct CompareCosmicQuasarPtr {
 class CosmicQuasar {
 private:
     double _quasar_dist;
-    std::unique_ptr<double[]> _rrmat, _icov;
 public:
     std::unique_ptr<qio::QSOFile> qFile;
     int N, fidx;
@@ -50,6 +49,7 @@ public:
     std::unique_ptr<float[]> r, chi;
     std::unique_ptr<double[]> y, Cy, residual, search, y_isig,
                               sod_cinv_eta, _z1_mem;
+    std::unique_ptr<double[]> _rrmat, _icov;
 
     std::set<size_t> grid_indices;
     std::set<const CosmicQuasar*, CompareCosmicQuasarPtr<CosmicQuasar>> neighbors;
@@ -413,6 +413,7 @@ public:
             for (int i = 0; i < N; ++i)
                 ccov[(i + 1) * N] -= di;
             mxhelp::copyUpperToLower(ccov, N);
+            mxhelp::copyUpperToLower(_rrmat.get(), N);
 
             cblas_dsymm(
                 CblasRowMajor, CblasLeft, CblasUpper,

--- a/qu3d/cosmic_quasar.hpp
+++ b/qu3d/cosmic_quasar.hpp
@@ -400,6 +400,39 @@ public:
         }
     }
 
+    void cacheCholeskyCov(
+            const fidcosmo::ArinyoP3DModel *p3d_model, bool cmarg=false,
+            bool small_scale=false, double alpha=0, double s=1.0
+    ) {
+        double *ccov = _icov.get();
+        if (small_scale)
+            setCov_S(p3d_model, ccov, alpha, s);
+        else
+            setCov(p3d_model, ccov);
+
+        lapack_int info = LAPACKE_dpotrf(LAPACK_ROW_MAJOR, 'U', N,
+                                         ccov, N);
+        if (cmarg) {
+            cblas_dsymm(
+                CblasRowMajor, CblasLeft, CblasUpper,
+                N, N, 1.,  _rrmat.get(), N,
+                ccov, N,
+                0, GL_CCOV[myomp::getThreadNum()].get(), N);
+            cblas_dsymm(
+                CblasRowMajor, CblasRight, CblasUpper,
+                N, N, 1.,  _rrmat.get(), N,
+                GL_CCOV[myomp::getThreadNum()].get(), N,
+                0, ccov, N);
+        }
+        if (info != 0)
+            LOG::LOGGER.ERR("Error in CosmicQuasar::multInvCov::LAPACKE_dposv.\n");
+    }
+
+    void solveCachedCholesky(const double *input, double *output) {
+        std::copy_n(input, N, output);
+        LAPACKE_dpotrs(LAPACK_ROW_MAJOR, 'U', N, 1, _icov.get(), N, output, 1);
+    }
+
     void interpMesh2Out(const RealField3D &mesh) {
         for (int i = 0; i < N; ++i)
             out[i] = mesh.forwardInterpolate(r.get() + 3 * i);

--- a/qu3d/cosmic_quasar.hpp
+++ b/qu3d/cosmic_quasar.hpp
@@ -413,7 +413,6 @@ public:
             for (int i = 0; i < N; ++i)
                 ccov[(N + 1) * i] -= di;
             mxhelp::copyUpperToLower(ccov, N);
-            mxhelp::copyUpperToLower(_rrmat.get(), N);
 
             cblas_dsymm(
                 CblasRowMajor, CblasLeft, CblasUpper,

--- a/qu3d/cosmic_quasar.hpp
+++ b/qu3d/cosmic_quasar.hpp
@@ -39,6 +39,7 @@ struct CompareCosmicQuasarPtr {
 class CosmicQuasar {
 private:
     double _quasar_dist;
+    std::unique_ptr<double[]> _rrmat, _icov;
 public:
     std::unique_ptr<qio::QSOFile> qFile;
     int N, fidx;
@@ -348,7 +349,8 @@ public:
         #endif
         // -- core function
             double *rrmat = GL_RMAT[myomp::getThreadNum()].get();
-            ioh::continuumMargFileHandler->read(N, qFile->id, rrmat);
+            if (_rrmat)  rrmat = _rrmat.get();
+            else  ioh::continuumMargFileHandler->read(N, qFile->id, rrmat);
             cblas_dsymv(CblasRowMajor, CblasUpper, N, 1.0,
                         rrmat, N, input, 1, 0, in_isig, 1);
         // --
@@ -568,12 +570,17 @@ public:
         std::erase_if(neighbors, lowOverlap);
     }
 
-    void constructMarginalization(int order) {
+    void constructMarginalization(int order, bool in_memory=false) {
         /* assumes order >= 0 */
         int nvecs = order + 1;
 
         double *ccov = GL_CCOV[myomp::getThreadNum()].get(),
                *rrmat = GL_RMAT[myomp::getThreadNum()].get();
+        if (in_memory) {
+            // Note final sqrt order is different
+            ccov = _rrmat.get();
+            rrmat = _icov.get();
+        }
         auto Emat = std::make_unique<double[]>(nvecs * nvecs);
         std::vector<std::unique_ptr<double[]>> uvecs(nvecs);
         for (int a = 0; a < nvecs; ++a)

--- a/qu3d/cosmic_quasar.hpp
+++ b/qu3d/cosmic_quasar.hpp
@@ -141,7 +141,7 @@ public:
     }
     CosmicQuasar(CosmicQuasar &&rhs) = delete;
     CosmicQuasar(const CosmicQuasar &rhs) = delete;
-    void allocMore() {
+    void allocRmatAndCovMatrices() {
         _rrmat = std::make_unique<double[]>(N * N);
         _icov = std::make_unique<double[]>(N * N);
     }

--- a/qu3d/cosmic_quasar.hpp
+++ b/qu3d/cosmic_quasar.hpp
@@ -142,8 +142,8 @@ public:
     CosmicQuasar(CosmicQuasar &&rhs) = delete;
     CosmicQuasar(const CosmicQuasar &rhs) = delete;
     void allocMore() {
-        _rrmat = std:make_unique<double[]>(N * N);
-        _icov = std:make_unique<double[]>(N * N);
+        _rrmat = std::make_unique<double[]>(N * N);
+        _icov = std::make_unique<double[]>(N * N);
     }
 
     void project(double varlss, int order) {

--- a/qu3d/cosmic_quasar.hpp
+++ b/qu3d/cosmic_quasar.hpp
@@ -410,9 +410,11 @@ public:
         else
             setCov(p3d_model, ccov);
 
-        lapack_int info = LAPACKE_dpotrf(LAPACK_ROW_MAJOR, 'U', N,
-                                         ccov, N);
         if (cmarg) {
+            double di = small_scale ? alpha - 1.0 / s : 1.0;
+            for (int i = 0; i < N; ++i)
+                ccov[(i + 1) * N] -= di;
+
             cblas_dsymm(
                 CblasRowMajor, CblasLeft, CblasUpper,
                 N, N, 1.,  _rrmat.get(), N,
@@ -423,7 +425,13 @@ public:
                 N, N, 1.,  _rrmat.get(), N,
                 GL_CCOV[myomp::getThreadNum()].get(), N,
                 0, ccov, N);
+
+            for (int i = 0; i < N; ++i)
+                ccov[(i + 1) * N] += di;
         }
+
+        lapack_int info = LAPACKE_dpotrf(LAPACK_ROW_MAJOR, 'U', N,
+                                         ccov, N);
         if (info != 0)
             LOG::LOGGER.ERR("Error in CosmicQuasar::multInvCov::LAPACKE_dposv.\n");
     }

--- a/qu3d/cosmic_quasar.hpp
+++ b/qu3d/cosmic_quasar.hpp
@@ -141,6 +141,10 @@ public:
     }
     CosmicQuasar(CosmicQuasar &&rhs) = delete;
     CosmicQuasar(const CosmicQuasar &rhs) = delete;
+    void allocMore() {
+        _rrmat = std:make_unique<double[]>(N * N);
+        _icov = std:make_unique<double[]>(N * N);
+    }
 
     void project(double varlss, int order) {
         /* Assumes isig is ivar. */

--- a/qu3d/cosmic_quasar.hpp
+++ b/qu3d/cosmic_quasar.hpp
@@ -616,17 +616,13 @@ public:
         std::erase_if(neighbors, lowOverlap);
     }
 
-    void constructMarginalization(int order, bool in_memory=false) {
+    void constructMarginalization(int order) {
         /* assumes order >= 0 */
         int nvecs = order + 1;
 
         double *ccov = GL_CCOV[myomp::getThreadNum()].get(),
                *rrmat = GL_RMAT[myomp::getThreadNum()].get();
-        if (in_memory) {
-            // Note final sqrt order is different
-            ccov = _rrmat.get();
-            rrmat = _icov.get();
-        }
+
         auto Emat = std::make_unique<double[]>(nvecs * nvecs);
         std::vector<std::unique_ptr<double[]>> uvecs(nvecs);
         for (int a = 0; a < nvecs; ++a)

--- a/qu3d/cosmic_quasar.hpp
+++ b/qu3d/cosmic_quasar.hpp
@@ -328,7 +328,9 @@ public:
         #endif
         // -- core function
             double *rrmat = GL_RMAT[myomp::getThreadNum()].get();
-            ioh::continuumMargFileHandler->read(N, qFile->id, rrmat);
+            if (_rrmat)  rrmat = _rrmat.get();
+            else  ioh::continuumMargFileHandler->read(N, qFile->id, rrmat);
+
             cblas_dsymv(CblasRowMajor, CblasUpper, N, 1.0,
                         rrmat, N, in, 1, 0, in_isig, 1);
 

--- a/qu3d/cosmic_quasar.hpp
+++ b/qu3d/cosmic_quasar.hpp
@@ -405,24 +405,23 @@ public:
             bool small_scale=false, double alpha=0, double s=1.0
     ) {
         double *ccov = _icov.get();
-        if (small_scale)
-            setCov_S(p3d_model, ccov, alpha, s);
-        else
-            setCov(p3d_model, ccov);
+        if (small_scale)  setCov_S(p3d_model, ccov, alpha, s);
+        else  setCov(p3d_model, ccov);
 
         if (cmarg) {
             double di = small_scale ? alpha - 1.0 / s : 1.0;
             for (int i = 0; i < N; ++i)
                 ccov[(i + 1) * N] -= di;
+            mxhelp::copyUpperToLower(ccov, N);
 
             cblas_dsymm(
                 CblasRowMajor, CblasLeft, CblasUpper,
-                N, N, 1.,  _rrmat.get(), N,
+                N, N, 1., _rrmat.get(), N,
                 ccov, N,
                 0, GL_CCOV[myomp::getThreadNum()].get(), N);
             cblas_dsymm(
                 CblasRowMajor, CblasRight, CblasUpper,
-                N, N, 1.,  _rrmat.get(), N,
+                N, N, 1., _rrmat.get(), N,
                 GL_CCOV[myomp::getThreadNum()].get(), N,
                 0, ccov, N);
 
@@ -430,10 +429,9 @@ public:
                 ccov[(i + 1) * N] += di;
         }
 
-        lapack_int info = LAPACKE_dpotrf(LAPACK_ROW_MAJOR, 'U', N,
-                                         ccov, N);
+        lapack_int info = LAPACKE_dpotrf(LAPACK_ROW_MAJOR, 'U', N, ccov, N);
         if (info != 0)
-            LOG::LOGGER.ERR("Error in CosmicQuasar::multInvCov::LAPACKE_dposv.\n");
+            LOG::LOGGER.ERR("Error in CosmicQuasar::cacheCholeskyCov::LAPACKE_dpotrf.\n");
     }
 
     void solveCachedCholesky(const double *input, double *output) {

--- a/qu3d/optimal_qu3d.cpp
+++ b/qu3d/optimal_qu3d.cpp
@@ -1102,6 +1102,30 @@ void Qu3DEstimator::conjugateGradientDescent() {
 
     if (verbose)
         LOG::LOGGER.STD("  Entered conjugateGradientDescent.\n");
+    
+    std::function<void(std::unique_ptr<CosmicQuasar> &qso,
+                const double *input, double *output)> preconditioner;
+    if (KEEP_MATRICES_IN_MEMORY) {
+        #pragma omp parallel for schedule(static, 8)
+        for (auto &qso : quasars)
+            qso->cacheCholeskyCov(p3d_model.get(), CONT_MARG_ENABLED);
+        
+        preconditioner = [](
+                std::unique_ptr<CosmicQuasar> &qso,
+                const double *input, double *output
+        ) {
+            qso->solveCachedCholesky(input, output);
+        };
+    }
+    else {
+        fidcosmo::ArinyoP3DModel *p = p3d_model.get();
+        preconditioner = [p](
+                std::unique_ptr<CosmicQuasar> &qso,
+                const double *input, double *output
+        ) {
+            qso->multInvCov(p, input, output);
+        };
+    }
 
     if (CONT_MARG_ENABLED) {
         /* Marginalize. Then, initial guess */
@@ -1109,7 +1133,7 @@ void Qu3DEstimator::conjugateGradientDescent() {
         for (auto &qso : quasars) {
             qso->multInputWithMarg(qso->truth);
             std::swap(qso->truth, qso->in_isig);
-            qso->multInvCov(p3d_model.get(), qso->truth, qso->in);
+            preconditioner(qso, qso->truth, qso->in);
         }
         ioh::continuumMargFileHandler->rewind();
         ++timings["Marg"].first;
@@ -1119,7 +1143,7 @@ void Qu3DEstimator::conjugateGradientDescent() {
         /* Initial guess */
         #pragma omp parallel for schedule(dynamic, 8)
         for (auto &qso : quasars)
-            qso->multInvCov(p3d_model.get(), qso->truth, qso->in);
+            preconditioner(qso, qso->truth, qso->in);
     }
 
     multiplyCovVector();
@@ -1133,7 +1157,7 @@ void Qu3DEstimator::conjugateGradientDescent() {
         qso->in = qso->search.get();
 
         // set search = InvCov . residual
-        qso->multInvCov(p3d_model.get(), qso->residual.get(), qso->in);
+        preconditioner(qso, qso->residual.get(), qso->in);
 
         init_residual_norm += cblas_ddot(qso->N, qso->residual.get(), 1,
                                          qso->residual.get(), 1);
@@ -1202,7 +1226,7 @@ void Qu3DEstimator::conjugateGradientDescent() {
         #pragma omp parallel for reduction(+:new_residual_prec)
         for (auto &qso : quasars) {
             // set z (out) = InvCov . residual
-            qso->multInvCov(p3d_model.get(), qso->residual.get(), qso->out);
+            preconditioner(qso, qso->residual.get(), qso->out);
             new_residual_prec += cblas_ddot(qso->N, qso->residual.get(), 1,
                                             qso->out, 1);
         }

--- a/qu3d/optimal_qu3d.cpp
+++ b/qu3d/optimal_qu3d.cpp
@@ -787,6 +787,10 @@ Qu3DEstimator::Qu3DEstimator(ConfigFile &configg) : config(configg) {
         else  _readNeighbors(neighbors_file);
     }
 
+    if (KEEP_MATRICES_IN_MEMORY)
+        for (auto &qso : quasars)
+            qso->allocMore();
+
     bool end_imm = (test_gaussian_field && (mock_grid_res_factor > 1));
     if (CONT_MARG_ENABLED && !end_imm)
         _createRmatFiles(unique_prefix);
@@ -794,11 +798,6 @@ Qu3DEstimator::Qu3DEstimator(ConfigFile &configg) : config(configg) {
     #pragma omp parallel for
     for (auto &qso : quasars)
         qso->transformZ1toG(p3d_model.get());
-    
-    if (KEEP_MATRICES_IN_MEMORY) {
-        for (auto &qso : quasars)
-            qso->allocMore();
-    }
 }
 
 void Qu3DEstimator::reverseInterpolate(RealField3D &m) {

--- a/qu3d/optimal_qu3d.cpp
+++ b/qu3d/optimal_qu3d.cpp
@@ -117,7 +117,7 @@ inline bool hasConverged(
     if (verbose && drate > 0)
         LOG::LOGGER.STD("    Smoothed descent rate is %.3f.\n", drate);
 
-    return (norm < tolerance) || (rel_norm < tolerance);
+    return (norm < 1e-2 * tolerance) || (rel_norm < tolerance);
 }
 
 
@@ -795,7 +795,7 @@ Qu3DEstimator::Qu3DEstimator(ConfigFile &configg) : config(configg) {
 
     if (KEEP_MATRICES_IN_MEMORY)
         for (auto &qso : quasars)
-            qso->allocMore();
+            qso->allocRmatAndCovMatrices();
 
     bool end_imm = (test_gaussian_field && (mock_grid_res_factor > 1));
     if (CONT_MARG_ENABLED && !end_imm)
@@ -967,7 +967,7 @@ void Qu3DEstimator::multiplyCovVector(bool mesh_enabled) {
 }
 
 
-double Qu3DEstimator::updateY(double residual_norm2) {
+double Qu3DEstimator::updateY(double residual_norm2, bool check_curvature) {
     double t1 = mytime::timer.getTime(), t2 = 0;
 
     double pTCp = 0, norm_p = 0, norm_Cp = 0,
@@ -983,8 +983,6 @@ double Qu3DEstimator::updateY(double residual_norm2) {
         norm_Cp += cblas_ddot(qso->N, qso->out, 1, qso->out, 1);
         pTCp += cblas_ddot(qso->N, qso->in, 1, qso->out, 1);
     }
-    norm_p *= norm_Cp * 1e-14;
-    norm_p = sqrt(norm_p);
 
     if (pTCp <= 0) {
         LOG::LOGGER.ERR("Negative pTCp = %.9e (All), ", pTCp);
@@ -1016,7 +1014,9 @@ double Qu3DEstimator::updateY(double residual_norm2) {
         return 0;
     }
 
-    if (pTCp < norm_p)  return -1.0;
+    // Zero Curvature check
+    norm_p = 1e-14 * sqrt(norm_p * norm_Cp);
+    if (check_curvature && (pTCp < norm_p))  return -1.0;
 
     alpha = residual_norm2 / pTCp;
 
@@ -1037,6 +1037,48 @@ double Qu3DEstimator::updateY(double residual_norm2) {
         LOG::LOGGER.STD("    updateY took %.2f s.\n", 60.0 * t2);
 
     return sqrt(new_residual_norm);
+}
+
+
+bool Qu3DEstimator::calculateExactResidual(
+        double &true_residual_norm, double threshold
+) {
+    if (verbose)  LOG::LOGGER.STD("    Exact calculation of residuals. ");
+    bool init_verbose = verbose;
+    verbose = false;
+
+    for (auto &qso : quasars)
+        qso->in = qso->y.get();
+
+    updateYMatrixVectorFunction();
+
+    true_residual_norm = 0;
+    double drift_norm = 0;
+
+    #pragma omp parallel for reduction(+:true_residual_norm, drift_norm)
+    for (auto &qso : quasars) {
+        for (int i = 0; i < qso->N; ++i) {
+            double r = qso->truth[i] - qso->out[i];
+            qso->out[i] = qso->residual[i] - r;
+            qso->residual[i] = r;
+        }
+
+        true_residual_norm += cblas_ddot(
+            qso->N, qso->residual.get(), 1, qso->residual.get(), 1);
+        drift_norm += cblas_ddot(qso->N, qso->out, 1, qso->out, 1);
+        qso->in = qso->search.get();
+    }
+    true_residual_norm = sqrt(true_residual_norm);
+    drift_norm = sqrt(drift_norm) / true_residual_norm;
+    restart = drift_norm > threshold;
+
+    verbose = init_verbose;
+
+    if (verbose)
+        LOG::LOGGER.STD("Drift: %.2e. %s\n", drift_norm,
+            restart ? "RESTARTING!!!" : "Continuing...");
+
+    return restart;
 }
 
 
@@ -1200,36 +1242,8 @@ void Qu3DEstimator::conjugateGradientDescent() {
         if (restart && verbose)
             LOG::LOGGER.STD("    WARNING: Flat curvature. Restarting.\n");
 
-        if (niter % 100 == 0) {
-            if (verbose)  LOG::LOGGER.STD("    Exact calculation of residuals. ");
-            for (auto &qso : quasars)
-                qso->in = qso->y.get();
-
-            updateYMatrixVectorFunction();
-            double true_residual_norm = 0, drift_norm = 0;
-
-            #pragma omp parallel for reduction(+:true_residual_norm, drift_norm)
-            for (auto &qso : quasars) {
-                for (int i = 0; i < qso->N; ++i) {
-                    double r = qso->truth[i] - qso->out[i];
-                    qso->out[i] = qso->residual[i] - r;
-                    qso->residual[i] = r;
-                }
-
-                true_residual_norm += cblas_ddot(
-                    qso->N, qso->residual.get(), 1, qso->residual.get(), 1);
-                drift_norm += cblas_ddot(qso->N, qso->out, 1, qso->out, 1);
-                qso->in = qso->search.get();
-            }
-            true_residual_norm = sqrt(true_residual_norm);
-            drift_norm = sqrt(drift_norm) / true_residual_norm;
-            new_residual_norm = true_residual_norm;
-            restart |= drift_norm > 0.01;
-
-            if (verbose)
-                LOG::LOGGER.STD("Drift: %.2e. %s.\n", drift_norm,
-                    restart ? "Restarting" : "Continuing");
-        }
+        if (niter % 100 == 0)
+            restart |= calculateExactResidual(new_residual_norm)
 
         conv_vec.push_back(new_residual_norm / truth_norm);
         double descent_rate = calculateDescentRate();

--- a/qu3d/optimal_qu3d.cpp
+++ b/qu3d/optimal_qu3d.cpp
@@ -1145,7 +1145,7 @@ void Qu3DEstimator::conjugateGradientDescent() {
 
     for (; niter <= max_conj_grad_steps; ++niter) {
         restart = false;
-        new_residual_norm = updateY(old_residual_prec) / truth_norm;
+        new_residual_norm = updateY(old_residual_prec);
         restart = new_residual_norm == -1;
 
         if (restart && verbose)

--- a/qu3d/optimal_qu3d.cpp
+++ b/qu3d/optimal_qu3d.cpp
@@ -979,9 +979,9 @@ double Qu3DEstimator::updateY(double residual_norm2, bool check_curvature) {
     // Get pT . C . p
     #pragma omp parallel for reduction(+:pTCp, norm_p, norm_Cp)
     for (const auto &qso : quasars) {
-        norm_p += cblas_ddot(qso->N, qso->in, 1, qso->in, 1);
-        norm_Cp += cblas_ddot(qso->N, qso->out, 1, qso->out, 1);
-        pTCp += cblas_ddot(qso->N, qso->in, 1, qso->out, 1);
+        norm_p += myQsoDot(qso, in, in);
+        norm_Cp += myQsoDot(qso, out, out);
+        pTCp += myQsoDot(qso, in, out);
     }
 
     if (pTCp <= 0) {
@@ -995,8 +995,8 @@ double Qu3DEstimator::updateY(double residual_norm2, bool check_curvature) {
         for (auto &qso : quasars) {
             for (int i = 0; i < qso->N; ++i)
                 qso->out[i] *= qso->isig[i] * qso->z1[i];
-            pTCp += cblas_ddot(qso->N, qso->in, 1, qso->out, 1);
-            alpha += cblas_ddot(qso->N, qso->in, 1, qso->in, 1);
+            pTCp += myQsoDot(qso, in, out);
+            alpha += myQsoDot(qso, in, in);
         }
 
         LOG::LOGGER.ERR("pTp = %.9e, pTS_Lp = %.9e, ", alpha, pTCp);
@@ -1007,7 +1007,7 @@ double Qu3DEstimator::updateY(double residual_norm2, bool check_curvature) {
             qso->multCovNeighbors(p3d_model.get(), effective_chi);
             for (int i = 0; i < qso->N; ++i)
                 qso->out[i] *= qso->isig[i] * qso->z1[i];
-            pTCp += cblas_ddot(qso->N, qso->in, 1, qso->out, 1);
+            pTCp += myQsoDot(qso, in, out);
         }
 
         LOG::LOGGER.ERR("pTS_Sp = %.9e.\n", pTCp);
@@ -1028,8 +1028,7 @@ double Qu3DEstimator::updateY(double residual_norm2, bool check_curvature) {
         cblas_daxpy(qso->N, alpha, qso->in, 1, qso->y.get(), 1);
         cblas_daxpy(qso->N, -alpha, qso->out, 1, qso->residual.get(), 1);
 
-        new_residual_norm += cblas_ddot(
-            qso->N, qso->residual.get(), 1, qso->residual.get(), 1);
+        new_residual_norm += myQsoDot(qso, residual.get(), residual.get());
     }
 
     t2 = mytime::timer.getTime() - t1;
@@ -1063,14 +1062,13 @@ bool Qu3DEstimator::calculateExactResidual(
             qso->residual[i] = r;
         }
 
-        true_residual_norm += cblas_ddot(
-            qso->N, qso->residual.get(), 1, qso->residual.get(), 1);
-        drift_norm += cblas_ddot(qso->N, qso->out, 1, qso->out, 1);
+        true_residual_norm += myQsoDot(qso, residual.get(), residual.get());
+        drift_norm += myQsoDot(qso, out, out);
         qso->in = qso->search.get();
     }
     true_residual_norm = sqrt(true_residual_norm);
     drift_norm = sqrt(drift_norm) / true_residual_norm;
-    restart = drift_norm > threshold;
+    bool restart = drift_norm > threshold;
 
     verbose = init_verbose;
 
@@ -1219,11 +1217,9 @@ void Qu3DEstimator::conjugateGradientDescent() {
         // set search = InvCov . residual
         preconditioner(qso, qso->residual.get(), qso->in);
 
-        init_residual_norm += cblas_ddot(qso->N, qso->residual.get(), 1,
-                                         qso->residual.get(), 1);
-        old_residual_prec += cblas_ddot(qso->N, qso->residual.get(), 1,
-                                        qso->in, 1);
-        truth_norm += cblas_ddot(qso->N, qso->truth, 1, qso->truth, 1);
+        init_residual_norm += myQsoDot(qso, residual.get(), residual.get());
+        old_residual_prec += myQsoDot(qso, residual.get(), in);
+        truth_norm += myQsoDot(qso, truth, truth);
     }
 
     init_residual_norm = sqrt(init_residual_norm);
@@ -1243,7 +1239,7 @@ void Qu3DEstimator::conjugateGradientDescent() {
             LOG::LOGGER.STD("    WARNING: Flat curvature. Restarting.\n");
 
         if (niter % 100 == 0)
-            restart |= calculateExactResidual(new_residual_norm)
+            restart |= calculateExactResidual(new_residual_norm);
 
         conv_vec.push_back(new_residual_norm / truth_norm);
         double descent_rate = calculateDescentRate();
@@ -1259,8 +1255,7 @@ void Qu3DEstimator::conjugateGradientDescent() {
         for (auto &qso : quasars) {
             // set z (out) = InvCov . residual
             preconditioner(qso, qso->residual.get(), qso->out);
-            new_residual_prec += cblas_ddot(qso->N, qso->residual.get(), 1,
-                                            qso->out, 1);
+            new_residual_prec += myQsoDot(qso, residual.get(), out);
         }
 
         double beta = restart ? 0 : new_residual_prec / old_residual_prec;

--- a/qu3d/optimal_qu3d.cpp
+++ b/qu3d/optimal_qu3d.cpp
@@ -41,7 +41,7 @@ std::unique_ptr<ioh::ContMargFile> ioh::continuumMargFileHandler;
 
 int NUMBER_OF_P_BANDS = 0;
 double DK_BIN = 0;
-bool verbose = true, CONT_MARG_ENABLED = false;
+bool verbose = true, CONT_MARG_ENABLED = false, KEEP_MATRICES_IN_MEMORY = false;
 constexpr bool INPLACE_FFT = true;
 
 
@@ -624,7 +624,8 @@ void Qu3DEstimator::_createRmatFiles(const std::string &prefix) {
 
         #pragma omp parallel for schedule(static, 8)
         for (auto &qso : quasars)
-            qso->constructMarginalization(specifics::CONT_LOGLAM_MARG_ORDER);
+            qso->constructMarginalization(specifics::CONT_LOGLAM_MARG_ORDER,
+                                          KEEP_MATRICES_IN_MEMORY);
 
         ioh::continuumMargFileHandler->closeAllWriters();
 
@@ -646,7 +647,8 @@ void Qu3DEstimator::_createRmatFiles(const std::string &prefix) {
         quasars[i]->fidx = q_fidx[i];
     }
 
-    ioh::continuumMargFileHandler->openAllReaders();
+    if (!KEEP_MATRICES_IN_MEMORY)
+        ioh::continuumMargFileHandler->openAllReaders();
     t2 = mytime::timer.getTime();
     LOG::LOGGER.STD("It took %.2f m.\n", t2 - t1);
 }
@@ -739,6 +741,7 @@ Qu3DEstimator::Qu3DEstimator(ConfigFile &configg) : config(configg) {
     number_of_multipoles = config.getInteger("NumberOfMultipoles");
     shrink_factor_for_sqrt = config.getDouble("ShrinkFactorForSqrt");
     CONT_MARG_ENABLED = specifics::CONT_LOGLAM_MARG_ORDER > -1;
+    KEEP_MATRICES_IN_MEMORY = config.getInteger("KeepMatricesInMemory") > 0;
 
     if (CONT_MARG_ENABLED && unique_prefix.empty())
         throw std::invalid_argument("Need UniquePrefixTmp when marginalizing.");
@@ -791,6 +794,10 @@ Qu3DEstimator::Qu3DEstimator(ConfigFile &configg) : config(configg) {
     #pragma omp parallel for
     for (auto &qso : quasars)
         qso->transformZ1toG(p3d_model.get());
+    
+    if (KEEP_MATRICES_IN_MEMORY) {
+
+    }
 }
 
 void Qu3DEstimator::reverseInterpolate(RealField3D &m) {

--- a/qu3d/optimal_qu3d.cpp
+++ b/qu3d/optimal_qu3d.cpp
@@ -796,7 +796,8 @@ Qu3DEstimator::Qu3DEstimator(ConfigFile &configg) : config(configg) {
         qso->transformZ1toG(p3d_model.get());
     
     if (KEEP_MATRICES_IN_MEMORY) {
-
+        for (auto &qso : quasars)
+            qso->allocMore();
     }
 }
 

--- a/qu3d/optimal_qu3d.cpp
+++ b/qu3d/optimal_qu3d.cpp
@@ -103,17 +103,21 @@ void logTimings() {
 }
 
 
-inline bool hasConverged(double norm, double tolerance, double drate=0) {
+inline bool hasConverged(
+        double norm, double base, double tolerance, double drate=0
+) {
+    double rel_norm = norm / base;
+
     if (verbose)
         LOG::LOGGER.STD(
-            "    Current norm(residuals) / norm(initial residuals) is %.3e. "
+            "    Current ||r|| / ||b|| = %.3e / %.3e = %.3e. "
             "Conjugate Gradient converges when this is < %.2e\n",
-            norm, tolerance);
+            norm, base, rel_norm, tolerance);
 
     if (verbose && drate > 0)
         LOG::LOGGER.STD("    Smoothed descent rate is %.3f.\n", drate);
 
-    return norm < tolerance;
+    return (norm < tolerance) || (rel_norm < tolerance);
 }
 
 
@@ -953,15 +957,20 @@ void Qu3DEstimator::multiplyCovVector(bool mesh_enabled) {
 double Qu3DEstimator::updateY(double residual_norm2) {
     double t1 = mytime::timer.getTime(), t2 = 0;
 
-    double pTCp = 0, alpha = 0, new_residual_norm = 0;
+    double pTCp = 0, norm_p = 0, norm_Cp = 0,
+           alpha = 0, new_residual_norm = 0;
 
     /* Multiply C x search into Cy => C. p(in) = out*/
     updateYMatrixVectorFunction();
 
     // Get pT . C . p
-    #pragma omp parallel for reduction(+:pTCp)
-    for (const auto &qso : quasars)
+    #pragma omp parallel for reduction(+:pTCp, norm_p, norm_Cp)
+    for (const auto &qso : quasars) {
+        norm_p += cblas_ddot(qso->N, qso->in, 1, qso->in, 1);
+        norm_Cp += cblas_ddot(qso->N, qso->out, 1, qso->out, 1);
         pTCp += cblas_ddot(qso->N, qso->in, 1, qso->out, 1);
+    }
+    norm_p *= norm_Cp * 1e-14;
 
     if (pTCp <= 0) {
         LOG::LOGGER.ERR("Negative pTCp = %.9e (All), ", pTCp);
@@ -992,6 +1001,8 @@ double Qu3DEstimator::updateY(double residual_norm2) {
         LOG::LOGGER.ERR("pTS_Sp = %.9e.\n", pTCp);
         return 0;
     }
+
+    if (pTCp < norm_p)  return -1.0;
 
     alpha = residual_norm2 / pTCp;
 
@@ -1057,9 +1068,10 @@ void Qu3DEstimator::conjugateGradientDescent() {
 
     double dt = mytime::timer.getTime();
     int niter = 1;
+    bool restart = false;
 
     double init_residual_norm = 0, old_residual_prec = 0,
-           new_residual_norm = 0;
+           new_residual_norm = 0, truth_norm = 0;
 
     std::vector<double> conv_vec;
     conv_vec.reserve(max_conj_grad_steps + 1);
@@ -1072,6 +1084,8 @@ void Qu3DEstimator::conjugateGradientDescent() {
 
         double sum = 0.0, weights = 0.0;
         for (size_t i = i0; i < conv_vec.size(); ++i) {
+            if (conv_vec[i] == -1.0)
+                continue;
             double w = (i - i0 + 1.0);
             sum += exp(-log(conv_vec[i]) / i) * w;
             weights += w;
@@ -1103,7 +1117,7 @@ void Qu3DEstimator::conjugateGradientDescent() {
 
     multiplyCovVector();
 
-    #pragma omp parallel for reduction(+:init_residual_norm, old_residual_prec)
+    #pragma omp parallel for reduction(+:init_residual_norm, old_residual_prec, truth_norm)
     for (auto &qso : quasars) {
         for (int i = 0; i < qso->N; ++i)
             qso->residual[i] = qso->truth[i] - qso->out[i];
@@ -1118,20 +1132,60 @@ void Qu3DEstimator::conjugateGradientDescent() {
                                          qso->residual.get(), 1);
         old_residual_prec += cblas_ddot(qso->N, qso->residual.get(), 1,
                                         qso->in, 1);
+        truth_norm += cblas_ddot(qso->N, qso->truth, 1, qso->truth, 1);
     }
 
     init_residual_norm = sqrt(init_residual_norm);
+    truth_norm = sqrt(truth_norm);
     conv_vec.push_back(init_residual_norm);
-    if (hasConverged(init_residual_norm, tolerance))
+    if (absolute_tolerance) truth_norm = 1;
+
+    if (hasConverged(init_residual_norm, truth_norm, tolerance))
         goto endconjugateGradientDescent;
 
-    if (absolute_tolerance) init_residual_norm = 1;
-
     for (; niter <= max_conj_grad_steps; ++niter) {
-        new_residual_norm = updateY(old_residual_prec) / init_residual_norm;
+        restart = false;
+        new_residual_norm = updateY(old_residual_prec, niter % 50);
+        restart = new_residual_norm == -1;
+
+        if (restart && verbose)
+            LOG::LOGGER.STD("    WARNING: Flat curvature. Restarting.\n");
+
+        if (niter % 50 == 0) {
+            if (verbose)  LOG::LOGGER.STD("    Exact calculation of residuals. ");
+            for (auto &qso : quasars)
+                qso->in = qso->y.get();
+
+            updateYMatrixVectorFunction();
+            double true_residual_norm = 0, drift_norm = 0;
+
+            #pragma omp parallel for reduction(+:true_residual_norm, drift_norm)
+            for (auto &qso : quasars) {
+                for (int i = 0; i < qso->N; ++i) {
+                    double r = qso->truth[i] - qso->out[i];
+                    qso->out[i] = qso->residual[i] - r;
+                    qso->residual[i] = r;
+                }
+
+                true_residual_norm += cblas_ddot(
+                    qso->N, qso->residual.get(), 1, qso->residual.get(), 1);
+                drift_norm += cblas_ddot(qso->N, qso->out, 1, qso->out, 1);
+                qso->in = qso->search.get();
+            }
+            true_residual_norm = sqrt(true_residual_norm);
+            drift_norm = sqrt(drift_norm) / true_residual_norm;
+            new_residual_norm = true_residual_norm;
+            restart |= drift_norm > 0.01;
+
+            if (verbose)
+                LOG::LOGGER.STD("Drift: %.2e. %s.\n", drift_norm,
+                    restart ? "Restarting" : "Continuing");
+        }
+
         conv_vec.push_back(new_residual_norm);
         double descent_rate = calculateDescentRate();
-        bool end_iter = hasConverged(new_residual_norm, tolerance, descent_rate);
+        bool end_iter = hasConverged(
+            new_residual_norm, truth_norm, tolerance, descent_rate);
 
         if (end_iter)
             goto endconjugateGradientDescent;
@@ -1146,7 +1200,7 @@ void Qu3DEstimator::conjugateGradientDescent() {
                                             qso->out, 1);
         }
 
-        double beta = new_residual_prec / old_residual_prec;
+        double beta = restart ? 0 : new_residual_prec / old_residual_prec;
         old_residual_prec = new_residual_prec;
 
         // New direction using preconditioned z = InvCov . residual

--- a/qu3d/optimal_qu3d.cpp
+++ b/qu3d/optimal_qu3d.cpp
@@ -1145,7 +1145,7 @@ void Qu3DEstimator::conjugateGradientDescent() {
 
     for (; niter <= max_conj_grad_steps; ++niter) {
         restart = false;
-        new_residual_norm = updateY(old_residual_prec, niter % 50);
+        new_residual_norm = updateY(old_residual_prec);
         restart = new_residual_norm == -1;
 
         if (restart && verbose)

--- a/qu3d/optimal_qu3d.cpp
+++ b/qu3d/optimal_qu3d.cpp
@@ -971,6 +971,7 @@ double Qu3DEstimator::updateY(double residual_norm2) {
         pTCp += cblas_ddot(qso->N, qso->in, 1, qso->out, 1);
     }
     norm_p *= norm_Cp * 1e-14;
+    norm_p = sqrt(norm_p);
 
     if (pTCp <= 0) {
         LOG::LOGGER.ERR("Negative pTCp = %.9e (All), ", pTCp);
@@ -1084,8 +1085,7 @@ void Qu3DEstimator::conjugateGradientDescent() {
 
         double sum = 0.0, weights = 0.0;
         for (size_t i = i0; i < conv_vec.size(); ++i) {
-            if (conv_vec[i] == -1.0)
-                continue;
+            if (conv_vec[i] < 0)  continue;
             double w = (i - i0 + 1.0);
             sum += exp(-log(conv_vec[i]) / i) * w;
             weights += w;
@@ -1136,7 +1136,7 @@ void Qu3DEstimator::conjugateGradientDescent() {
     }
 
     init_residual_norm = sqrt(init_residual_norm);
-    truth_norm = sqrt(truth_norm);
+    truth_norm = std::max(sqrt(truth_norm), init_residual_norm);
     conv_vec.push_back(init_residual_norm);
     if (absolute_tolerance) truth_norm = 1;
 
@@ -1145,13 +1145,13 @@ void Qu3DEstimator::conjugateGradientDescent() {
 
     for (; niter <= max_conj_grad_steps; ++niter) {
         restart = false;
-        new_residual_norm = updateY(old_residual_prec);
+        new_residual_norm = updateY(old_residual_prec) / truth_norm;
         restart = new_residual_norm == -1;
 
         if (restart && verbose)
             LOG::LOGGER.STD("    WARNING: Flat curvature. Restarting.\n");
 
-        if (niter % 50 == 0) {
+        if (niter % 100 == 0) {
             if (verbose)  LOG::LOGGER.STD("    Exact calculation of residuals. ");
             for (auto &qso : quasars)
                 qso->in = qso->y.get();
@@ -1182,7 +1182,7 @@ void Qu3DEstimator::conjugateGradientDescent() {
                     restart ? "Restarting" : "Continuing");
         }
 
-        conv_vec.push_back(new_residual_norm);
+        conv_vec.push_back(new_residual_norm / truth_norm);
         double descent_rate = calculateDescentRate();
         bool end_iter = hasConverged(
             new_residual_norm, truth_norm, tolerance, descent_rate);

--- a/qu3d/optimal_qu3d.cpp
+++ b/qu3d/optimal_qu3d.cpp
@@ -1040,6 +1040,40 @@ double Qu3DEstimator::updateY(double residual_norm2) {
 }
 
 
+std::function<
+    void(std::unique_ptr<CosmicQuasar> &qso, const double *in, double *o)
+> Qu3DEstimator::getPreconditioner(bool small_scale, double mp, double s) {
+    std::function<void(
+        std::unique_ptr<CosmicQuasar> &qso, const double *in, double *o
+    )> preconditioner;
+
+    if (KEEP_MATRICES_IN_MEMORY) {
+        #pragma omp parallel for schedule(static, 8)
+        for (auto &qso : quasars)
+            qso->cacheCholeskyCov(p3d_model.get(), CONT_MARG_ENABLED,
+                                  small_scale, mp, s);
+
+        preconditioner = [](
+                std::unique_ptr<CosmicQuasar> &qso,
+                const double *input, double *output
+        ) {
+            qso->solveCachedCholesky(input, output);
+        };
+    }
+    else {
+        fidcosmo::ArinyoP3DModel *p = p3d_model.get();
+        preconditioner = [p, small_scale, mp, s](
+                std::unique_ptr<CosmicQuasar> &qso,
+                const double *input, double *output
+        ) {
+            qso->multInvCov(p, input, output, small_scale, mp, s);
+        };
+    }
+
+    return preconditioner;
+}
+
+
 void Qu3DEstimator::preconditionerSolution() {
     double dt = mytime::timer.getTime();
 
@@ -1109,29 +1143,7 @@ void Qu3DEstimator::conjugateGradientDescent() {
     if (verbose)
         LOG::LOGGER.STD("  Entered conjugateGradientDescent.\n");
     
-    std::function<void(std::unique_ptr<CosmicQuasar> &qso,
-                const double *input, double *output)> preconditioner;
-    if (KEEP_MATRICES_IN_MEMORY) {
-        #pragma omp parallel for schedule(static, 8)
-        for (auto &qso : quasars)
-            qso->cacheCholeskyCov(p3d_model.get(), CONT_MARG_ENABLED);
-        
-        preconditioner = [](
-                std::unique_ptr<CosmicQuasar> &qso,
-                const double *input, double *output
-        ) {
-            qso->solveCachedCholesky(input, output);
-        };
-    }
-    else {
-        fidcosmo::ArinyoP3DModel *p = p3d_model.get();
-        preconditioner = [p](
-                std::unique_ptr<CosmicQuasar> &qso,
-                const double *input, double *output
-        ) {
-            qso->multInvCov(p, input, output);
-        };
-    }
+    auto preconditioner = getPreconditioner();
 
     if (CONT_MARG_ENABLED) {
         /* Marginalize. Then, initial guess */

--- a/qu3d/optimal_qu3d.cpp
+++ b/qu3d/optimal_qu3d.cpp
@@ -647,8 +647,14 @@ void Qu3DEstimator::_createRmatFiles(const std::string &prefix) {
         quasars[i]->fidx = q_fidx[i];
     }
 
-    if (!KEEP_MATRICES_IN_MEMORY)
-        ioh::continuumMargFileHandler->openAllReaders();
+    ioh::continuumMargFileHandler->openAllReaders();
+    if (KEEP_MATRICES_IN_MEMORY) {
+        #pragma omp parallel for schedule(static, 8)
+        for (auto &qso : quasars)
+            ioh::continuumMargFileHandler->read(
+                qso->N, qso->qFile->id, qso->_rrmat.get());
+        ioh::continuumMargFileHandler->closeAllReaders();
+    }
     t2 = mytime::timer.getTime();
     LOG::LOGGER.STD("It took %.2f m.\n", t2 - t1);
 }

--- a/qu3d/optimal_qu3d.hpp
+++ b/qu3d/optimal_qu3d.hpp
@@ -124,6 +124,9 @@ class Qu3DEstimator
     bool _syncMonteCarlo(int nmc, double *o1, double *o2,
                          int ndata, const std::string &ext);
 
+    std::function<
+        void(std::unique_ptr<CosmicQuasar> &qso, const double *in, double *o)
+    > getPreconditioner(bool small_scale=false, double mp=0, double s=1);
 public:
     int mock_grid_res_factor;
     bool total_bias_enabled, total_bias_direct_enabled, noise_bias_enabled,

--- a/qu3d/optimal_qu3d.hpp
+++ b/qu3d/optimal_qu3d.hpp
@@ -70,7 +70,7 @@ const config_map qu3d_default_parameters ({
     {"PadeOrder", "4"}, {"ShrinkFactorForSqrt", "0.0"},
     {"TestHsqrt", "-1"}, {"UniquePrefixTmp", ""}, {"NeighborsCache", ""},
     {"DeconvolveCICWindow", "-1"}, {"MixtureFactorForAs", "1.0"},
-    {"ReverseInterpolationThreadNum", "3"}
+    {"ReverseInterpolationThreadNum", "3"}, {"KeepMatricesInMemory", "0"}
 });
 
 

--- a/qu3d/optimal_qu3d.hpp
+++ b/qu3d/optimal_qu3d.hpp
@@ -124,6 +124,12 @@ class Qu3DEstimator
     bool _syncMonteCarlo(int nmc, double *o1, double *o2,
                          int ndata, const std::string &ext);
 
+    /* Block-diagonal preconditioner. This returns a function that should be
+    used as follows (schematically)
+        #pragma omp parallel for
+        for (auto &qso : quasars)
+            preconditioner(qso, qso->(input), qso->(output));
+    */
     std::function<
         void(std::unique_ptr<CosmicQuasar> &qso, const double *in, double *o)
     > getPreconditioner(bool small_scale=false, double mp=0, double s=1);
@@ -194,7 +200,12 @@ public:
     void reverseInterpolateZ(RealField3D &m);
     /* Reverse interopates qso->in x qso->isig onto the mesh */
     void reverseInterpolateIsig(RealField3D &m);
-    double updateY(double residual_norm2);
+    /* Returns -1 for zero-curvature check */
+    double updateY(double residual_norm2, bool check_curvature=false);
+    /* Uses qso->y.get() as input to updateYMatrixVectorFunction. 
+    Then swaps back to qso->seach.get(). Returns true to restart.
+    */
+    bool calculateExactResidual(double &true_residual_norm, double threshold=0.01);
     /* Solve (I + N^-1/2 S N^-1/2) z = m, until z converges,
     where y = N^-1/2 z and m = truth = N^-1/2 delta. Then get y if z2y=true.
     */

--- a/qu3d/optimal_qu3d_extra.cpp
+++ b/qu3d/optimal_qu3d_extra.cpp
@@ -121,7 +121,7 @@ void Qu3DEstimator::conjugateGradientSampler() {
 
     init_residual_norm = sqrt(old_residual_norm2);
 
-    if (hasConverged(init_residual_norm, tolerance))
+    if (hasConverged(init_residual_norm, 1.0, tolerance))
         goto endconjugateGradientSampler;
 
     if (absolute_tolerance) init_residual_norm = 1;
@@ -130,7 +130,7 @@ void Qu3DEstimator::conjugateGradientSampler() {
         double new_residual_norm2 = updateRng(old_residual_norm2);
 
         bool end_iter = hasConverged(
-            sqrt(new_residual_norm2) / init_residual_norm, tolerance);
+            sqrt(new_residual_norm2), init_residual_norm, tolerance);
 
         if (end_iter)
             goto endconjugateGradientSampler;

--- a/qu3d/optimal_qu3d_mc.cpp
+++ b/qu3d/optimal_qu3d_mc.cpp
@@ -88,7 +88,7 @@ void Qu3DEstimator::conjugateGradientIpH(double m, double s) {
     int niter = 1;
 
     double init_residual_norm = 0, old_residual_prec = 0,
-           new_residual_norm = 0;
+           new_residual_norm = 0, truth_norm = 0;
 
     updateYMatrixVectorFunction = [this, m, s]() { multiplyAsVector(m, s); };
 
@@ -107,7 +107,7 @@ void Qu3DEstimator::conjugateGradientIpH(double m, double s) {
     multiplyAsVector(m, s);
 
     #pragma omp parallel for schedule(dynamic, 4) \
-                             reduction(+:init_residual_norm, old_residual_prec)
+                             reduction(+:init_residual_norm, old_residual_prec, truth_norm)
     for (auto &qso : quasars) {
         for (int i = 0; i < qso->N; ++i)
             qso->residual[i] = qso->truth[i] - qso->out[i];
@@ -122,19 +122,20 @@ void Qu3DEstimator::conjugateGradientIpH(double m, double s) {
                                          qso->residual.get(), 1);
         old_residual_prec += cblas_ddot(qso->N, qso->residual.get(), 1,
                                         qso->in, 1);
+        truth_norm += cblas_ddot(qso->N, qso->truth, 1, qso->truth, 1);
     }
 
     init_residual_norm = sqrt(init_residual_norm);
+    truth_norm = sqrt(truth_norm);
+    if (absolute_tolerance) truth_norm = 1;
 
-    if (hasConverged(init_residual_norm, tolerance))
+    if (hasConverged(init_residual_norm, truth_norm, tolerance))
         goto endconjugateGradientIpH;
-
-    if (absolute_tolerance) init_residual_norm = 1;
 
     for (; niter <= max_conj_grad_steps; ++niter) {
         new_residual_norm = updateY(old_residual_prec) / init_residual_norm;
 
-        bool end_iter = hasConverged(new_residual_norm, tolerance);
+        bool end_iter = hasConverged(new_residual_norm, truth_norm, tolerance);
 
         if (end_iter)
             goto endconjugateGradientIpH;

--- a/qu3d/optimal_qu3d_mc.cpp
+++ b/qu3d/optimal_qu3d_mc.cpp
@@ -96,13 +96,13 @@ void Qu3DEstimator::conjugateGradientIpH(double m, double s) {
     double mp = m - (1.0 - mixture_factor_for_as) / s;
     if (verbose)
         LOG::LOGGER.STD("  Entered conjugateGradientIpH.\n");
-
-    #define PRECONDITIONER(X, Y) qso->multInvCov(p3d_model.get(), X, Y, true, mp, s);
+    
+    auto preconditioner = getPreconditioner(true, mp, s);
 
     /* Initial guess */
     #pragma omp parallel for schedule(dynamic, 4)
     for (auto &qso : quasars)
-        PRECONDITIONER(qso->truth, qso->in);
+        preconditioner(qso, qso->truth, qso->in);
 
     multiplyAsVector(m, s);
 
@@ -116,7 +116,7 @@ void Qu3DEstimator::conjugateGradientIpH(double m, double s) {
         qso->in = qso->search.get();
 
         // set search = PreCon . residual
-        PRECONDITIONER(qso->residual.get(), qso->in);
+        preconditioner(qso, qso->residual.get(), qso->in);
 
         init_residual_norm += cblas_ddot(qso->N, qso->residual.get(), 1,
                                          qso->residual.get(), 1);
@@ -126,14 +126,14 @@ void Qu3DEstimator::conjugateGradientIpH(double m, double s) {
     }
 
     init_residual_norm = sqrt(init_residual_norm);
-    truth_norm = sqrt(truth_norm);
+    truth_norm = std::max(sqrt(truth_norm), init_residual_norm);
     if (absolute_tolerance) truth_norm = 1;
 
     if (hasConverged(init_residual_norm, truth_norm, tolerance))
         goto endconjugateGradientIpH;
 
     for (; niter <= max_conj_grad_steps; ++niter) {
-        new_residual_norm = updateY(old_residual_prec) / init_residual_norm;
+        new_residual_norm = updateY(old_residual_prec);
 
         bool end_iter = hasConverged(new_residual_norm, truth_norm, tolerance);
 
@@ -146,12 +146,10 @@ void Qu3DEstimator::conjugateGradientIpH(double m, double s) {
                                  reduction(+:new_residual_prec)
         for (auto &qso : quasars) {
             // set z (out) = PreCon . residual
-            PRECONDITIONER(qso->residual.get(), qso->out);
+            preconditioner(qso, qso->residual.get(), qso->out);
             new_residual_prec += cblas_ddot(qso->N, qso->residual.get(), 1,
                                             qso->out, 1);
         }
-
-        #undef PRECONDITIONER
 
         double beta = new_residual_prec / old_residual_prec;
         old_residual_prec = new_residual_prec;

--- a/qu3d/optimal_qu3d_mc.cpp
+++ b/qu3d/optimal_qu3d_mc.cpp
@@ -118,11 +118,9 @@ void Qu3DEstimator::conjugateGradientIpH(double m, double s) {
         // set search = PreCon . residual
         preconditioner(qso, qso->residual.get(), qso->in);
 
-        init_residual_norm += cblas_ddot(qso->N, qso->residual.get(), 1,
-                                         qso->residual.get(), 1);
-        old_residual_prec += cblas_ddot(qso->N, qso->residual.get(), 1,
-                                        qso->in, 1);
-        truth_norm += cblas_ddot(qso->N, qso->truth, 1, qso->truth, 1);
+        init_residual_norm += myQsoDot(qso, residual.get(), residual.get());
+        old_residual_prec += myQsoDot(qso, residual.get(), in);
+        truth_norm += myQsoDot(qso, truth, truth);
     }
 
     init_residual_norm = sqrt(init_residual_norm);
@@ -147,8 +145,7 @@ void Qu3DEstimator::conjugateGradientIpH(double m, double s) {
         for (auto &qso : quasars) {
             // set z (out) = PreCon . residual
             preconditioner(qso, qso->residual.get(), qso->out);
-            new_residual_prec += cblas_ddot(qso->N, qso->residual.get(), 1,
-                                            qso->out, 1);
+            new_residual_prec += myQsoDot(qso, residual.get(), out);
         }
 
         double beta = new_residual_prec / old_residual_prec;
@@ -517,20 +514,20 @@ void Qu3DEstimator::testCovSqrt() {
         for (auto &qso : quasars) {
             rngs[myomp::getThreadNum()].fillVectorNormal(qso->truth, qso->N);
             std::copy_n(qso->truth, qso->N, qso->in);
-            xTx += cblas_ddot(qso->N, qso->in, 1, qso->in, 1);
+            xTx += myQsoDot(qso, in, in);
         }
 
         multiplyAsVector();
 
         #pragma omp parallel for reduction(+:xTHx)
         for (auto &qso : quasars)
-            xTHx += cblas_ddot(qso->N, qso->in, 1, qso->out, 1);
+            xTHx += myQsoDot(qso, in, out);
 
         multiplyCovSmallSqrtPade();
         // multiplyCovSmallSqrtNewtonSchulz(pade_order);
         #pragma omp parallel for reduction(+:yTy)
         for (auto &qso : quasars)
-            yTy += cblas_ddot(qso->N, qso->truth, 1, qso->truth, 1);
+            yTy += myQsoDot(qso, truth, truth);
 
         xTx_arr[i - 1] = xTx;  xTHx_arr[i - 1] = xTHx;  yTy_arr[i - 1] = yTy;
         ++prog_tracker;


### PR DESCRIPTION
A preconditioner is constructed that includes Marginalization matrices, such that CG now converges rapidly. These matrices can now be saved to memory if specified in the config, significantly speeding up the computation.

Additionally, advanced CG Checks are introduced:
- Zero curvature check in the updateY function
- Exact calculation of residuals at every 100 iterations, and restarting if the drift is large.
- Absolute convergence check on top of relative.
- The relative convergence basis is compared to the norm of the truth vector, in case the preconditioner is extremely good for an initial guess.